### PR TITLE
Fix JavaScript for solr-utils and add sortChildren for kmapstree

### DIFF
--- a/app/assets/javascripts/kmaps_engine/jquery.kmapstree.js
+++ b/app/assets/javascripts/kmaps_engine/jquery.kmapstree.js
@@ -28,6 +28,7 @@
             },
             expand_path: null,
             // baseUrl: "http://subjects.kmaps.virginia.edu/"
+            sortChildren: true,
         };
 
     // copied from jquery.fancytree.js to support moved loadKeyPath function
@@ -391,7 +392,9 @@
                     console.log("loadChildren...");
                   }
 
-                  ctx.node.sortChildren(null, true);
+                  if(plugin.settings.sortChildren){
+                    ctx.node.sortChildren(null, true);
+                  }
 
                 }
               }).on('fancytreeinit', function (x, y) {

--- a/app/assets/javascripts/kmaps_engine/solr-utils.js
+++ b/app/assets/javascripts/kmaps_engine/solr-utils.js
@@ -214,18 +214,18 @@
       var response = data.response;
       if(response.numFound > 0){
         var result = response.docs.reduce(function(acc,currentNode,index){
-          let node_type = currentNode["related_kmaps_node_type"] ;
+          var node_type = currentNode["related_kmaps_node_type"] ;
           if(node_type === undefined) {
             node_type = "other";
           }
           if(acc[node_type] === undefined){
             acc[node_type] =  [];
           }
-          let relation_label = currentNode["related_"+ plugin.settings.domain +"_relation_label_s"];
+          var relation_label = currentNode["related_"+ plugin.settings.domain +"_relation_label_s"];
           if(acc[node_type][relation_label] === undefined){
             acc[node_type][relation_label] = [];
           }
-          let node_id = currentNode['related_'+plugin.settings.domain+'_id_s'];
+          var node_id = currentNode['related_'+plugin.settings.domain+'_id_s'];
           acc[node_type][relation_label][node_id] = currentNode;
           return acc;
         }, []);


### PR DESCRIPTION
This branch fixes the error on the assets:precompile due to use of ES6 standard let
and Adds the option for the flyout kmapstree to sortChildren