### PR TITLE
Fix bibliographical reference for Online Resources

### DIFF
--- a/app/models/citation.rb
+++ b/app/models/citation.rb
@@ -65,10 +65,12 @@ class Citation < ActiveRecord::Base
       pages = self.web_pages
       if pages.count==1
         source_str = pages.first.full_path
-      else
+      elsif pages.count > 1
         pages_a = pages.to_a
         e = pages_a.shift
         source_str = ([e.full_path] + a.collect(&:path)).join(', ')
+      else
+        source_str = "#{source.titles.first.title} #{(source.web_address.url)}"
       end
     else
       source_str = ([source.bibliographic_reference] + self.pages.collect(&:to_s)).join(', ') + '.'

--- a/app/models/citation.rb
+++ b/app/models/citation.rb
@@ -70,8 +70,9 @@ class Citation < ActiveRecord::Base
         e = pages_a.shift
         source_str = ([e.full_path] + a.collect(&:path)).join(', ')
       else
-        source_str = "#{source.titles.first.title} #{(source.web_address.url)}"
+        source_str = source.web_address.url
       end
+      source_str = "#{source.prioritized_title} (#{source_str})"
     else
       source_str = ([source.bibliographic_reference] + self.pages.collect(&:to_s)).join(', ') + '.'
     end

--- a/app/views/features/_feature.html.erb
+++ b/app/views/features/_feature.html.erb
@@ -1,4 +1,3 @@
-<%= javascript_on_load("ActivateDraggablePopups('.has-draggable-popups');") %>
 <%= content_tag :h6, "#{feature_name_header(feature)} #{edit_item_link(admin_feature_path(feature.fid)) if logged_in? && object_authorized?(feature)}".html_safe %>
 <%= time_units_for(feature) %>
 <%  summary = feature.summary
@@ -103,3 +102,8 @@
     </div>
   </section>
 </div>
+<%= javascript_on_load do %>
+      jQuery('[data-js-kmaps-popup]').kmapsPopup({
+        type: POPUP_TYPE_INFO,
+      });
+<%  end %>


### PR DESCRIPTION
An error occurs when an MMSIntegration citation was found and it didn't
contain any pages, the case was not being taken into account, that was
fixed and added some of the code for the citations to be displayed on
the _feature partial.

MANU-4932