### PR TITLE
Fix fly-out search for text with spaces

### DIFF
--- a/app/assets/javascripts/kmaps_engine/jquery.kmaps-typeahead.js
+++ b/app/assets/javascripts/kmaps_engine/jquery.kmaps-typeahead.js
@@ -132,7 +132,7 @@
               var solr_query = settings.autocomplete_field + ':' + val.replace(/[\s\u0f0b\u0f0d]+/g, '\\ ');
               if(settings.search_fields){
                 solr_query = settings.search_fields.reduce(function(full_query,search_field){
-                  return full_query+" OR "+search_field+":"+orig_val;
+                  return full_query+" OR "+search_field+":"+val.replace(/[\s]+/g, '\\ ');
                 },solr_query);
               }
               extras = {

--- a/lib/kmaps_engine/version.rb
+++ b/lib/kmaps_engine/version.rb
@@ -1,3 +1,3 @@
 module KmapsEngine
-  VERSION = '5.1.8'
+  VERSION = '5.1.9'
 end


### PR DESCRIPTION
After fixing the search using Tibetan text an error was introduced, if
the text contained a space an invalid query was generated for Solr.

The fix is just a simple scape of spaces if they are found.