### PR TITLE
Add filter to handle commas in fly-out search - MANU-4046

### DIFF
--- a/app/assets/javascripts/kmaps_engine/jquery.kmaps-typeahead.js
+++ b/app/assets/javascripts/kmaps_engine/jquery.kmaps-typeahead.js
@@ -113,7 +113,7 @@
             var extras = {};
             var orig_val = input.val();
             //val = val.replace(/[\-\[\]\/\{\}\(\)\*\+\?\.\\\^\$\|]/g, "\\$&");
-            var val = orig_val.replace(/[\-\[\]\/\{\}\(\)\*\+\?\.\\\^\$\|]/g, " ");
+            var val = orig_val.replace(/[\-\[\]\/\{\}\(\)\*\+\?\.\,\/\\\^\$\|]/g, " ");
             switch(settings.match_criterion){
               case 'begins':
                 val = ""+val+"*";

--- a/lib/kmaps_engine/version.rb
+++ b/lib/kmaps_engine/version.rb
@@ -1,3 +1,3 @@
 module KmapsEngine
-  VERSION = '5.2.0'
+  VERSION = '5.2.1'
 end


### PR DESCRIPTION
Commas were not being taken care on the fly-out search when cleaning up
special characters, now it is properly handle.