### PR TITLE
Fix bug when deleting a general note - MANU-4986

### DIFF
--- a/app/controllers/admin/association_notes_controller.rb
+++ b/app/controllers/admin/association_notes_controller.rb
@@ -14,7 +14,13 @@ class Admin::AssociationNotesController < AclController
 
   create.wants.html { redirect_to polymorphic_url([:admin, object.notable, object]) }
   update.wants.html { redirect_to polymorphic_url([:admin, object.notable, object]) }
-  destroy.wants.html { redirect_to polymorphic_url([:admin, object.notable]) }
+  destroy.wants.html do
+    if object.notable.class == Feature
+      redirect_to admin_feature_url(object.notable.fid)
+    else
+      redirect_to polymorphic_url([:admin, object.notable])
+    end
+  end
   
   def initialize
     super

--- a/lib/kmaps_engine/version.rb
+++ b/lib/kmaps_engine/version.rb
@@ -1,3 +1,3 @@
 module KmapsEngine
-  VERSION = '5.1.9'
+  VERSION = '5.2.0'
 end


### PR DESCRIPTION
The problem was on the redirect, there redirect was linking back to
feature and the router was assuming to use :id but feautres routes
assumes :fid to be the one comming from the URL request.