### PR TITLE
Update hard-coded phonetic names for Dzonka - MANU-5040

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -78,7 +78,7 @@
   { code: 'eng.to.tib.script.transcrip', name: 'English-to-Tibetan Transcription',                description: "<p>This is for representing the sound of English words in Tibetans script.</p>" },
   { code: 'unident.tib.transcrip',       name: 'Unidentified System of Tibetan Transcription',    description: "<p>This is used for any transcription system used for Tibetan which is unknown. It may be a system not yet identified, or it might be just a popular rendering of the specific toponym in question without any underlying system behind it.</p>" },
   { code: 'chan.tib.transcrip',          name: 'Chan System of Tibetan Transcription',            description: "<p>This is the system used by Victor Chan to transcribe Tibetan in his book Tibet Handbook</p>" },
-  { code: 'dzo.to.eng.transcrip',        name: 'Dzongkha-to-English Transcription' },
+  { code: 'dzo.transcrip',               name: 'Dzongkha Transcription' },
   { code: 'wade.giles.transcrip',        name: 'Wade-Giles Transcription' },
   { code: 'amdo.transcrip',              name: 'Amdo Transcription' },
   { code: 'mon.to.chi.transcrip',        name: 'Mongolian-to-Chinese Transcription' }

--- a/lib/kmaps_engine/feature_extension_for_name_positioning.rb
+++ b/lib/kmaps_engine/feature_extension_for_name_positioning.rb
@@ -104,9 +104,9 @@ module FeatureExtensionForNamePositioning
       # language=dzo: Right now we mostly have only the latin version of these names, which is marked as original.
       when 'dzo'
         name = HelperMethods.find_name_for_writing_system(all_names, latin_id)
-        # Later we will get the writing system=dzongkha or writing system=tibt version, and then this latin version will be demoted to a derivative of those dzongkha script names with writing system=latn , and phonetic_systems=dzo.to.eng.transcript
+        # Later we will get the writing system=dzongkha or writing system=tibt version, and then this latin version will be demoted to a derivative of those dzongkha script names with writing system=latn , and phonetic_systems=dzo.transcrip
         # The new rule would look like this:
-        # name = HelperMethods.find_name_for_writing_and_phonetic_system(all_names, latin_id, PhoneticSystem.get_by_code('dzo.to.eng.transcript').id)  
+        # name = HelperMethods.find_name_for_writing_and_phonetic_system(all_names, latin_id, PhoneticSystem.get_by_code('dzo.transcrip').id)
       # language=mon; writing_systems=latn
       when 'mon'
         # orthographic_systems=thl.mongol.translit


### PR DESCRIPTION
A correction is going to be names:
NAME Dzongkha-to-English Transcription
CODE dzo.to.eng.transcrip

Needs to be changed to
NAME Dzongkha Transcription
CODE dzo.transcrip

This commit includes the changes to the hard-coded parts that
had this name.