### PR TITLE
Added support for feature_object_type in contextual_feature - THLTOOLS-3587

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -497,7 +497,7 @@ module ApplicationHelper
     feature = object if feature.nil? && defined?(object) && object.instance_of?(Feature)
     feature = case parent_type
     when :feature then parent_object
-    when :description, :feature_name, :feature_geo_code then parent_object.feature
+    when :description, :feature_name, :feature_geo_code, :feature_object_type then parent_object.feature
     when :feature_relation then parent_object.child_node
     when :feature_name_relation then parent_object.child_node.feature
     else nil

--- a/lib/kmaps_engine/version.rb
+++ b/lib/kmaps_engine/version.rb
@@ -1,3 +1,3 @@
 module KmapsEngine
-  VERSION = '5.2.5'
+  VERSION = '5.2.6'
 end


### PR DESCRIPTION
Contextual_feature allows us to know which feature is the parent of the
current object, it wasn't taking into account objects that were of type:
feature_object_type now it does.