### PR TITLE
Fix FeatureName error when deleting - MANU 5085

### DIFF
--- a/app/controllers/admin/feature_names_controller.rb
+++ b/app/controllers/admin/feature_names_controller.rb
@@ -45,7 +45,7 @@ class Admin::FeatureNamesController < AclController
   def destroy
     name = FeatureName.find(params[:id])
     name.destroy
-    redirect_to(:back)
+    redirect_back(fallback_location: admin_root_path)
   end
   
   protected

--- a/lib/kmaps_engine/version.rb
+++ b/lib/kmaps_engine/version.rb
@@ -1,3 +1,3 @@
 module KmapsEngine
-  VERSION = '5.2.4'
+  VERSION = '5.2.5'
 end


### PR DESCRIPTION
There was an bug on feature_names_controller when the feature name was
destroyed it had a redirected to :back, but we should use redirect_back
and have a fallback ULR if the HTTP_REFERER is not present.