### PR TITLE
Prevent click propagation for top menu click - MANU-5204

### DIFF
--- a/app/views/public/_view_list.html.erb
+++ b/app/views/public/_view_list.html.erb
@@ -6,7 +6,8 @@
     end
     view_path = change_view_session_path('a').chop %>
 <%=	javascript_on_load do %>
-      jQuery('.radio_view_pref').click(function (){
+      jQuery('.radio_view_pref').click(function (event){
+        event.stopPropagation();
         window.location.pathname = '<%= view_path %>' + this.value;
       });
 <%  end %>


### PR DESCRIPTION
There is a bug that is causing clicks to go through a stacked DOM
element to the elements behind. This is part of the solution, but it is
related to shanti_integration changes on the pointer events when the
menu is open or close.