### PR TITLE
Remove letters from flyout search results - MANU-5187

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,5 @@
+Jira Issue: [ID of issue in Jira if you don't have one go create one]
+Changes proposed in this pull request:
+[item 1 - replace me]
+[item 2 - replace me]
+Details of the implementation: [explain the reasoning behind the change so when we come back to this pull request we understand how and why the changes were made as they were]

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,5 +1,0 @@
-Jira Issue: [ID of issue in Jira if you don't have one go create one]
-Changes proposed in this pull request:
-[item 1 - replace me]
-[item 2 - replace me]
-Details of the implementation: [explain the reasoning behind the change so when we come back to this pull request we understand how and why the changes were made as they were]

--- a/app/assets/javascripts/kmaps_engine/flyout-kmaps-typeahead.js
+++ b/app/assets/javascripts/kmaps_engine/flyout-kmaps-typeahead.js
@@ -253,6 +253,7 @@
         empty_sort: plugin.options.empty_sort,
         sort: plugin.options.sort,
         filters: plugin.options.shanti_kmaps_admin_solr_filter_query ? plugin.options.shanti_kmaps_admin_solr_filter_query : '',
+        additional_filters: plugin.options.filters,
         autocomplete_field: plugin.options.autocomplete_field,
         prefetch_fields: plugin.options.prefetch_fields,
         prefetch_filters: plugin.options.prefetch_filters,

--- a/app/assets/javascripts/kmaps_engine/jquery.kmaps-typeahead.js
+++ b/app/assets/javascripts/kmaps_engine/jquery.kmaps-typeahead.js
@@ -28,6 +28,7 @@
       sort: '',
       fields: '',
       filters: '',
+      additional_filters: [],
       menu: '',
       no_results_msg: '',
       match_criterion: 'contains', //{contains, begins, exactly}
@@ -157,10 +158,16 @@
             if (query !== plugin.fake) {
               plugin.start = 0;
             }
+
+            var additional_filters = "";
+            settings.additional_filters.forEach(function(filter){
+              additional_filters += "&fq="+filter;
+            });
+
             $.extend(true, extras, plugin.params);
             remote.dataType = 'jsonp';
             remote.jsonp = 'json.wrf';
-            remote.url += '&' + $.param(extras, true);
+            remote.url += '&' + $.param(extras, true)+additional_filters;
             return remote;
           },
           filter: function (json) {


### PR DESCRIPTION
**Jira issue**: MANU-5187
**Changes proposed in this pull request**:
Remove head letters from results
**Details of implementation**:
This was done by handling the filter parameter sent by the terms_engine and adding them to the filter query sent to solr.

When we are constructing the flyoutKmapsTypeahead, we can now use the filter option for example:

```javascript
  $("#kmaps-explorer-search-term").flyoutKmapsTypeahead({
    hostname: "<%= Feature.config.url %>",
    hostname_assets: "<%= Flare.config.asset_url %>",
    domain: '<%= Feature.uid_prefix %>',
    filters_domain: '<%= Feature.uid_prefix %>',
    filters: ["-associated_subjects:Letter"],
    root_kmap_path: null,
    features_path: "<%= (defined?(admin) && admin) ? admin_features_path : features_path %>/%%ID%%"
  });
```