### PR TITLE
Add auto collapse option to KmapsTree and fix CSS for typeahead

### DIFF
--- a/app/assets/javascripts/kmaps_engine/jquery.kmapstree.js
+++ b/app/assets/javascripts/kmaps_engine/jquery.kmapstree.js
@@ -30,7 +30,8 @@
             // baseUrl: "http://subjects.kmaps.virginia.edu/"
             sortNodes: true,
             sortNodesBy: "header",
-            view: ""
+            view: "",
+            autoCollapse: false
         };
 
     // copied from jquery.fancytree.js to support moved loadKeyPath function
@@ -125,6 +126,7 @@
                 quicksearch: false,
                 checkbox: false,
                 selectMode: 2,
+                autoCollapse: plugin.settings.autoCollapse,
                 minExpandLevel: 1, // TODO: reconcile this with lazy loading.  Only "1" is supported currently.
                 theme: 'bootstrap',
                 debugLevel: 0,

--- a/app/assets/stylesheets/kmaps_engine/kmaps_typeahead.css.scss
+++ b/app/assets/stylesheets/kmaps_engine/kmaps_typeahead.css.scss
@@ -11,3 +11,6 @@
  *= require kmaps_typeahead/kmaps-typeahead
  */
 
+.advanced-view .kmaps-tt-hint{
+  padding-left: 30px;
+}

--- a/lib/kmaps_engine/version.rb
+++ b/lib/kmaps_engine/version.rb
@@ -1,3 +1,3 @@
 module KmapsEngine
-  VERSION = '5.3.3'
+  VERSION = '5.3.4'
 end


### PR DESCRIPTION
**Jira issue:** MANU-5257

**Changes proposed in this pull request:**

 + Add option for autoCollaps for KmapsTree
 + Add CSS to fix error on advanced search for Places

**Details of the implementation:**
KmapsTree now supports the option for auto collapse, this is when one
node is selected if there is an open node it will close. The default
behaviour is false (no auto collapse), to set it on send true to the
option autoCollapse.

Example:

```ruby
        $("#tree").kmapsTree({
          termindex_root: "<%= Feature.config.url %>",
          kmindex_root: "<%= MmsIntegration::Picture.config.url %>",
          type: "<%= Feature.uid_prefix %>", //subjects
          root_kmap_path: '',
          baseUrl: "<%= (defined?(admin) && admin) ? admin_features_path : features_path %>/%%ID%%",
          expand_path: "",
          perspective: "<%= current_perspective.code %>",
          view: "<%= current_view.code %>",
<%        unless feature.nil? %>
            activeNodeId: "<%= feature.fid %>",
<%        end %>
					sortNodes: true,
          sortNodesBy: "position_i",
          autoCollapse: false
        });
```

Fixed display bug for typeahead. When the option to show hint was
selected for advanced search, for places application, the hint appears to
the left making it hard to read the text. The CSS fix uses the selector
"advanced-view" to make sure it only affects the CSS for places advanced
search.