### PR TITLE
Add new simple typeahead library and Updated Kmaps relations tree

### DIFF
--- a/app/assets/javascripts/kmaps_engine/kmaps_relations_tree.js
+++ b/app/assets/javascripts/kmaps_engine/kmaps_relations_tree.js
@@ -40,6 +40,8 @@
       mandalaURL: "https://mandala.shanti.virginia.edu/%%APP%%/%%ID%%/%%REL%%/nojs",
       solrUtils: {}, //requires solr-utils.js library
       language: 'eng',
+      extraFields: [],
+      nodeMarkerPredicates: [], //A predicate is: {field:, value:, operation: 'eq', mark: 'nonInteractive'}
     };
 
   // The actual plugin constructor
@@ -66,6 +68,8 @@
         directAncestors: plugin.options.directAncestors,
         descendantsFullDetail: plugin.options.descendantsFullDetail,
         sortBy: plugin.options.sortBy,
+        extraFields: plugin.options.extraFields,
+        nodeMarkerPredicates: plugin.options.nodeMarkerPredicates,
       };
       // Place initialization logic here
       // You already have access to the DOM element and the options via the instance,
@@ -97,8 +101,12 @@
         activate: function(event, data){
           var node = data.node,
             orgEvent = data.originalEvent;
-          if(node.data.href){
-            window.location.href=node.data.href;
+          if(node.data.marks.includes('nonInteractiveNode')) {
+            node.toggleExpanded();
+          } else {
+            if(node.data.href){
+              window.location.href=node.data.href;
+            }
           }
         },
         lazyLoad: function(event,data){
@@ -127,10 +135,8 @@
               current_title+"</a>";
             if(parentPath == ""){
               return current_link;
-              return current_title;
             }
             return parentPath + "/" + current_link;
-            return parentPath + "/" + current_title;
           }, "");
           if(plugin.options.displayPopup){
             var pop_container = $('<span class="popover-kmaps" data-app="places" data-id="'+key+'"><span class="popover-kmaps-tip"></span><span class="icon shanticon-menu3"></span></span>');
@@ -182,9 +188,9 @@
       if(!plugin.options.directAncestors) {
         var ancestorPath = keyPath.split("/"+plugin.options.domain+"-");
         ancestorPath.shift();
-        return plugin.options.solrUtils.getDescendantsInPath(ancestorPath.join("/"),ancestorPath.length+1,plugin.options.sortBy);
+        return plugin.options.solrUtils.getDescendantsInPath(ancestorPath.join("/"),ancestorPath.length+1,plugin.options.sortBy,plugin.options.extraFields,plugin.options.nodeMarkerPredicates);
       }
-      return plugin.options.solrUtils.getDescendantTree(featureId,plugin.options.descendantsFullDetail,plugin.options.sortBy);
+      return plugin.options.solrUtils.getDescendantTree(featureId,plugin.options.descendantsFullDetail,plugin.options.sortBay,plugin.options.extraFields, plugin.options.nodeMarkerPredicates);
     }
   };
 

--- a/app/assets/javascripts/kmaps_engine/kmaps_typeahead.js
+++ b/app/assets/javascripts/kmaps_engine/kmaps_typeahead.js
@@ -14,3 +14,4 @@
 //= require typeahead/typeahead.jquery.min
 //= require kmaps_engine/jquery.kmaps-typeahead
 //= require kmaps_typeahead/kmaps-util
+//= require kmaps_engine/kmaps-simple-typeahead

--- a/app/controllers/admin/feature_names_controller.rb
+++ b/app/controllers/admin/feature_names_controller.rb
@@ -38,7 +38,7 @@ class Admin::FeatureNamesController < AclController
       feature.update_is_name_position_overriden
       feature.update_cached_feature_names
     end
-    render :nothing => true
+    render plain: ''
   end
   
   # Overwrite the default destroy method so we can redirect_to(:back)

--- a/app/controllers/preferences_controller.rb
+++ b/app/controllers/preferences_controller.rb
@@ -3,6 +3,6 @@ class PreferencesController < ApplicationController
   
   def edit
     session[:name_preferences][:filter] = params[:name_preferences_filter]
-    render :nothing => true, :status => 200
+    render plain: ''
   end
 end

--- a/app/views/admin/feature_names/prioritize.html.erb
+++ b/app/views/admin/feature_names/prioritize.html.erb
@@ -2,7 +2,7 @@
 <%= javascript_on_load do %>
   jQuery('#featureNamesList').ajaxSortable({
     action: '<%= set_priorities_admin_feature_names_path %>',
-    object_id: <%= @feature.id.to_s %>
+    object_id: <%= @feature.id %>
   });
 <% end
    add_breadcrumb_item feature_link(@feature)
@@ -32,7 +32,7 @@
        <th><%= ts 'priorit.y' %></th>
      </tr>
 <%   list.sort_by{ |l| l.position }.each do |item| %>
-       <tr id="feature_name_<%= item.id.to_s %>">
+       <tr id="feature_name_<%= item.id %>">
          <td class="centerText">
 <%       if @locating_relation %>
 <%=        form_tag new_admin_feature_name_feature_name_relation_path(@feature), {:method=>:get} %>
@@ -49,7 +49,7 @@
          <td><%= def_if_blank(item, :language) %></td>
          <td><%= def_if_blank(item, :writing_system) %></td>
          <td><%= fn_relationship(item) %></td>
-         <td class="sortable-priority-value"><%= item.position.to_s %></td>
+         <td class="sortable-priority-value"><%= item.position %></td>
        </tr>
 <%   end %>
      </table>

--- a/vendor/assets/stylesheets/kmaps_typeahead/kmaps-typeahead.css
+++ b/vendor/assets/stylesheets/kmaps_typeahead/kmaps-typeahead.css
@@ -71,28 +71,4 @@
 .kmaps-tt-dataset:not(:empty) + .kmaps-tt-dataset button.close {
     display: none;
 }
-
-/* BETTER CSS - maybe move to SARVAKA
-
-.kmaps-tt-menu {
-    min-width: 160px;
-    margin-top: 2px;
-    padding: 5px 0;
-    background-color: #fff;
-    border: 1px solid #ccc;
-    border: 1px solid rgba(0,0,0,.2);
-    *border-right-width: 2px;
-    *border-bottom-width: 2px;
-    -webkit-border-radius: 0.8rem;
-    -moz-border-radius: 0.8rem;
-    border-radius: 0.8rem;
-    -webkit-box-shadow: 0 5px 10px rgba(0,0,0,.2);
-    -moz-box-shadow: 0 5px 10px rgba(0,0,0,.2);
-    box-shadow: 0 5px 10px rgba(0,0,0,.2);
-    -webkit-background-clip: padding-box;
-    -moz-background-clip: padding;
-    background-clip: padding-box;
-}
-
-*/
-
+/* END - KMaps Fields CSS */


### PR DESCRIPTION
**Jira Issue:** MANU-5619, MANU-5623, MANU-5652

**Changes proposed in this pull request:**

 + added a new implementation of the typeahead library that can be used in
simple forms to add the typeahead capability.

+ relations tree - added new support for marking nodes if they match certain
criteria, this criteria is added via predicates on the tree options and
now the tree supports adding additional fields to query.

+ fixed issues with prioritization of feature names.

+ removed unnecessary CSS
**Details of the implementation:**

+ The new implementation of the simple typeahead, is as its name suggests, simple, it is not to be used as a complete replacement of the current implementation but as a small option when the queries are simple, new functionality can be added with time but the idea is to share the code with Mandala and Rails.

+ The implementation of the predicates allows the tree to be more flexible and we will be able to mark nodes depending on different criterion, for example, we could mark nodes that belong to a specific branch as no-public, or nodes that have names longer than 10 characters as needsSmallFont, etc. Any criteria that can be modelled by queries to the Solr index can be used.

+ Prior fix to places engine (MANU-5619 - https://github.com/thl/places_engine/pull/18) worked with the issues of prioritization for shapes, now the fix has been applied to feature_names in kmaps_engine.
