### PR TITLE
Add support to SolrUtils for View for KmapsRelationsTree - MANU-5779

### DIFF
--- a/app/assets/javascripts/kmaps_engine/kmaps_relations_tree.js
+++ b/app/assets/javascripts/kmaps_engine/kmaps_relations_tree.js
@@ -126,7 +126,7 @@
           var theIdPath = data.node.data.path;
           //var displayPath = data.node.data.displayPath;
           var displayPath = data.node.getParentList(true,true).reduce(function(parentPath,ancestor) {
-            var title_match = ancestor.title.match(/<strong>(.*?)<\/strong>/);
+            var title_match = ancestor.title;
             var current_title = "";
             if(title_match != null){
               current_title = title_match[0];

--- a/app/assets/javascripts/kmaps_engine/solr-utils.js
+++ b/app/assets/javascripts/kmaps_engine/solr-utils.js
@@ -23,6 +23,7 @@
       featureId: "places-1",
       domain: "places",
       perspective: "general",
+      view: 'roman.scholar',
       tree: 'places',
       featuresPath: "/features/%%ID%%"
     },
@@ -457,8 +458,8 @@
     var extraFields = options["extraFields"] ? options["extraFields"] : []
     var nodeMarkerPredicates = options["nodeMarkerPredicates"] ? options["nodeMarkerPredicates"] : []
     const dfd = $.Deferred();
-    const fieldList = [
-      "header",
+    const head = plugin.settings.view.blank? "header" : "header:name_"+plugin.settings.view
+    const fieldList = head + [
       "id",
       "ancestor_id_"+plugin.settings.perspective+"_path",
       "level_"+plugin.settings.perspective+"_i"
@@ -571,7 +572,7 @@
     const plugin = this;
     const dfd = $.Deferred();
     var fieldList = [
-      "header",
+      "header:name_"+plugin.settings.view,
       "id",
       "ancestor_id_"+plugin.settings.perspective+"_path",
       "ancestor_ids_"+plugin.settings.perspective,
@@ -677,7 +678,7 @@
     var nodeMarkerPredicates = options["nodeMarkerPredicates"] ? options["nodeMarkerPredicates"] : []
     const dfd = $.Deferred();
     const fieldList = [
-      "header",
+      "header:name_"+plugin.settings.view,
       "id",
       "ancestor_id_"+plugin.settings.perspective+"_path",
       "ancestor_ids_"+plugin.settings.perspective,
@@ -766,7 +767,7 @@
     fullDetail = fullDetail || false;
     const dfd = $.Deferred();
     var fieldList = [
-      "header",
+      "header:name_"+plugin.settings.view,
       "id",
       "ancestor_id_"+plugin.settings.perspective+"_path",
       "ancestors_"+plugin.settings.perspective,

--- a/lib/kmaps_engine/version.rb
+++ b/lib/kmaps_engine/version.rb
@@ -1,3 +1,3 @@
 module KmapsEngine
-  VERSION = '5.6.3'
+  VERSION = '5.6.4'
 end


### PR DESCRIPTION
**Jira Issue:** MANU-5779

**Changes proposed in this pull request:**

 + Add support on SolrUtils for views preferences for KmapsRelationsTree 

**Details of the implementation:**

Now KmapsRelationsTree supports View preferences on the display of the
tree, if the view is not set it uses header by default.
