### PR TITLE
Fix bug on Relations Tree and Added simple typeahead update filter - MANU-6076

### DIFF
--- a/app/assets/javascripts/kmaps_engine/kmaps-simple-typeahead.js
+++ b/app/assets/javascripts/kmaps_engine/kmaps-simple-typeahead.js
@@ -331,6 +331,10 @@
       }
     },
 
+    updateAdditionalFilters: function (filters) {
+      this.settings.additional_filters = filters;
+    },
+
     mergeParams: function (params) {
       this.params = params;
     },

--- a/app/assets/javascripts/kmaps_engine/kmaps_relations_tree.js
+++ b/app/assets/javascripts/kmaps_engine/kmaps_relations_tree.js
@@ -33,6 +33,7 @@
       perspective: "pol.admin.hier",
       descendants: false,
       directAncestors: true,
+      hideAncestors: false,
       descendantsFullDetail: true,
       sortBy: 'header_ssort+ASC',
       initialScrollToActive: false,
@@ -101,8 +102,10 @@
         activate: function(event, data){
           var node = data.node,
             orgEvent = data.originalEvent;
-          if(node.data.marks.includes('nonInteractiveNode')) {
+          if(node.data.marks && node.data.marks.includes('nonInteractiveNode')) {
             node.toggleExpanded();
+          } else if(node.data.marks && node.data.marks.includes('customActionNode')) {
+             return;
           } else {
             if(node.data.href){
               window.location.href=node.data.href;
@@ -178,7 +181,9 @@
     },
     getAncestorTree: function(options){
       const plugin = this;
-      if(plugin.options.directAncestors) {
+      if(plugin.options.hideAncestors) {
+        return plugin.options.solrUtils.getDescendantTree(plugin.options.featureId,plugin.options.descendantsFullDetail,plugin.options.sortBay,plugin.options.extraFields, plugin.options.nodeMarkerPredicates);
+      } else if(plugin.options.directAncestors) {
         return plugin.options.solrUtils.getAncestorTree(options);
       }
       return plugin.options.solrUtils.getFullAncestorTree(options);

--- a/app/assets/javascripts/kmaps_engine/solr-utils.js
+++ b/app/assets/javascripts/kmaps_engine/solr-utils.js
@@ -644,6 +644,8 @@
                 if (!currentNode[marker['field']].includes(marker['value'])) {
                   marks.push(marker['mark']);
                 }
+              } else if(marker['operation'] == 'markAll') {
+                  marks.push(marker['mark']);
               }
             });
           }
@@ -720,6 +722,27 @@
           ancestorsKey  = "ancestor_ids_closest_" + plugin.settings.perspective;
           ancestorsNameKey  = "ancestors_closest_" + plugin.settings.perspective;
         }
+          var marks = []
+          if (nodeMarkerPredicates.length > 0){
+            nodeMarkerPredicates.forEach(function(marker, index){
+              //marker['field'] marker['value'] marker['operation'] marker['mark']
+              if(marker['operation'] == '==') {
+                if (JSON.stringify(currentNode[marker['field']]) == JSON.stringify(marker.value)) {
+                  marks.push(marker['mark']);
+                }
+              } else if(marker['operation'] == 'includes') {
+                if (currentNode[marker['field']].includes(marker['value'])) {
+                  marks.push(marker['mark']);
+                }
+              } else if(marker['operation'] == '!includes') {
+                if (!currentNode[marker['field']].includes(marker['value'])) {
+                  marks.push(marker['mark']);
+                }
+              } else if(marker['operation'] == 'markAll') {
+                  marks.push(marker['mark']);
+              }
+            });
+          }
         const result = doc[ancestorsKey] === undefined ? [] : doc[ancestorsKey].reduceRight(function(acc,val,index){
           const node = {
             title: "<strong>" + doc[ancestorsNameKey][index] + "</strong>",
@@ -729,7 +752,8 @@
             lazy: true,
             displayPath: doc[ancestorsNameKey].join("/"),
             //[].concat to handle the instance when the children are sent as an argument
-            children: acc === undefined ? null : [].concat(acc)
+            children: acc === undefined ? null : [].concat(acc),
+            marks: marks,
           };
           if( node.key === plugin.settings.featureId) {
             node.active = true;
@@ -833,6 +857,27 @@
           if(fullDetail) {
             title += " (" +feature_type + currentNode["related_"+plugin.settings.domain+"_relation_label_s"]+")";
           }
+          var marks = []
+          if (nodeMarkerPredicates.length > 0){
+            nodeMarkerPredicates.forEach(function(marker, index){
+              //marker['field'] marker['value'] marker['operation'] marker['mark']
+              if(marker['operation'] == '==') {
+                if (JSON.stringify(currentNode[marker['field']]) == JSON.stringify(marker.value)) {
+                  marks.push(marker['mark']);
+                }
+              } else if(marker['operation'] == 'includes') {
+                if (currentNode[marker['field']].includes(marker['value'])) {
+                  marks.push(marker['mark']);
+                }
+              } else if(marker['operation'] == '!includes') {
+                if (!currentNode[marker['field']].includes(marker['value'])) {
+                  marks.push(marker['mark']);
+                }
+              } else if(marker['operation'] == 'markAll') {
+                  marks.push(marker['mark']);
+              }
+            });
+          }
           const child = {
             title: title,
             displayPath: "",//currentNode[ancestorsNameKey].join("/"),
@@ -840,6 +885,7 @@
             expanded: false,
             lazy: true,
             href: plugin.settings.featuresPath.replace("%%ID%%",key),
+            marks: marks,
           };
           if(currentNode["child_count"] !== undefined) {
             if(currentNode["child_count"]["numFound"] === 0) {

--- a/lib/kmaps_engine/version.rb
+++ b/lib/kmaps_engine/version.rb
@@ -1,3 +1,3 @@
 module KmapsEngine
-  VERSION = '5.6.8'
+  VERSION = '5.6.9'
 end


### PR DESCRIPTION
**Jira Issue:** MANU-6076

**Changes proposed in this pull request:**

 + Fixed bug on Relations Tree when there was no predicate set for marking nodes.
 + Added functionality to Kmaps-simple-typeahead so we are able to update the additional filters setting.
 + Add new functionality to Relations Tree, to hide ancestors.
 + Add new functionality to Relations Tree, for marking all nodes.
 + Add Solr-utils capability to mark root nodes.
 + Add support for customAction, so a new action can be assigned to the nodes when activated.

**Details of the implementation:**

There is a bug on Relations tree when a mark is not set for predicates,
 which seldom happens but can trigger an error.

Add new functionality to Kmaps simple typeahead to support updating the
additional filters setting.
