### PR TITLE
Fix bug on contextual_feature accessing session context - MANU-6102

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -33,7 +33,7 @@ class ApplicationController < ActionController::Base
   end
 
   def set_common_variables
-    session[:interface] ||= {}
+    session['interface'] ||= {}
 
     # Allow for views and perspectives to be set by GET params.  It might be possible to simplify this code...
     if params[:perspective_id] || params[:view_id]

--- a/app/controllers/features_controller.rb
+++ b/app/controllers/features_controller.rb
@@ -2,7 +2,7 @@ class FeaturesController < ApplicationController
   caches_page :show, :if => Proc.new { |c| c.request.format.xml? || c.request.format.json? || c.request.format.csv? }
   #
   def index
-    @feature = Feature.find(session[:interface][:context_id]) unless session[:interface].blank? || session[:interface][:context_id].blank?
+    @feature = Feature.find(session['interface']['context_id']) unless session['interface'].blank? || session['interface']['context_id'].blank?
     @tab_options = {:entity => @feature}
     @current_tab_id = :home
     
@@ -27,7 +27,7 @@ class FeaturesController < ApplicationController
         if @feature.nil?
           redirect_to features_url
         else
-          session[:interface][:context_id] = @feature.id unless @feature.nil?
+          session['interface']['context_id'] = @feature.id unless @feature.nil?
           @tab_options = {:entity => @feature}
           @current_tab_id = :place
         end
@@ -259,7 +259,7 @@ class FeaturesController < ApplicationController
     if @feature.nil?
       redirect_to features_url
     else
-      session[:interface][:context_id] = @feature.id unless @feature.nil?
+      session['interface']['context_id'] = @feature.id unless @feature.nil?
       @tab_options = {:entity => @feature}
       @current_tab_id = :related
     end
@@ -298,16 +298,16 @@ class FeaturesController < ApplicationController
       
   def set_session_variables
     defaults = {
-      :menu_item => "search",
-      :advanced_search => "0"
+      'menu_item' => 'search',
+      'advanced_search' => '0'
     }
     valid_keys = defaults.keys
     
-    session[:interface] = {} if session[:interface].nil?
+    session['interface'] = {} if session['interface'].nil?
     params.each do |key, value|
-      session[:interface][key.to_sym] = value if valid_keys.include?(key.to_sym)
+      session['interface'][key] = value if valid_keys.include?(key)
     end
-    render :text => ""
+    render :text => '' 
   end
   
   protected

--- a/app/controllers/media_controller.rb
+++ b/app/controllers/media_controller.rb
@@ -10,7 +10,7 @@ class MediaController < ApplicationController
       @object_type = "Media"
       @object_title = "Medium #{@medium.id}"
       @object_url = MmsIntegration::Medium.element_url(@medium.id, :format => 'html')
-      @feature = Feature.find(session[:interface][:context_id]) unless session[:interface].blank? || session[:interface][:context_id].blank?
+      @feature = Feature.find(session['interface']['context_id']) unless session['interface'].blank? || session['interface']['context_id'].blank?
       respond_to do |format|
         format.html { render :template => 'features/list' } # show.html.erb
         format.js   { render :template => 'features/paginated_list' }

--- a/app/controllers/preferences_controller.rb
+++ b/app/controllers/preferences_controller.rb
@@ -2,7 +2,7 @@ class PreferencesController < ApplicationController
   protect_from_forgery :except => :edit
   
   def edit
-    session[:name_preferences][:filter] = params[:name_preferences_filter]
+    session['name_preferences']['filter'] = params[:name_preferences_filter]
     render plain: ''
   end
 end

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -24,16 +24,16 @@ class SessionsController < ApplicationController
   def change_language
     case params[:id]
     when 'bo'
-      session[:language] = 'bo'
+      session['language'] = 'bo'
       self.current_view_id = View.get_by_code('pri.tib.sec.chi').id
     when 'dz'
-      session[:language] = 'dz'
+      session['language'] = 'dz'
       self.current_view_id = View.get_by_code('pri.tib.sec.roman').id
     when 'zh'
-      session[:language] = 'zh'
+      session['language'] = 'zh'
       self.current_view_id = View.get_by_code('simp.chi').id
     when 'en'
-      session[:language] = 'en'
+      session['language'] = 'en'
       self.current_view_id = View.get_by_code(default_view_code).id
     end
     redirect_back fallback_location: root_url

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -509,14 +509,21 @@ module ApplicationHelper
     end if feature.nil? && defined?(parent_type)
     feature = object.feature if feature.nil? && defined?(object) && object.respond_to?(:feature)
     if feature.nil? || feature.id.nil?
-      context_id = session[:interface].blank? ? nil : session[:interface][:context_id]
+      context_id = session['interface'].blank? ? nil : session['interface']['context_id']
+      context_id = nil
+      if !session['interface'].blank?
+        context_id = session['interface']['context_id']
+        if context_id.blank?
+          context_id = session['interface']['context_id']
+        end
+      end
       begin
         feature = Feature.find(context_id) if !context_id.blank?
       rescue ActiveRecord::RecordNotFound
         feature = nil
       end
     else
-      session[:interface][:context_id] = feature.id
+      session['interface']['context_id'] = feature.id
     end
     @contextual_feature = feature
   end

--- a/app/helpers/features_helper.rb
+++ b/app/helpers/features_helper.rb
@@ -113,6 +113,6 @@ module FeaturesHelper
   end
   
   def active_menu_item
-    !session[:interface].blank? && !session[:interface][:menu_item].blank? ? session[:interface][:menu_item] : 'browse'
+    !session['interface'].blank? && !session['interface']['menu_item'].blank? ? session['interface']['menu_item'] : 'browse'
   end
 end

--- a/app/views/features/_search_results.html.erb
+++ b/app/views/features/_search_results.html.erb
@@ -1,12 +1,12 @@
 <% use_session ||= false
    # This partial will only use the session store features as its results if use_session is true
-   # and the session[:search] variables aren't blank
-   if use_session && !session[:search][:page].blank?
+   # and the session['search'] variables aren't blank
+   if use_session && !session['search']['page'].blank?
      # Create a "fake" WillPaginate collection that has the same properties as a Feature collection would
-     pagination_collection = WillPaginate::Collection.new(session[:search][:page], session[:search][:per_page], session[:search][:total_entries])  
+     pagination_collection = WillPaginate::Collection.new(session['search']['page'], session['search']['per_page'], session['search']['total_entries'])  
      # This is necessary for calculations involving Collection.length to be correct
      pagination_collection.replace(features)
-     search_params = session[:search][:params]
+     search_params = session['search']['params']
      # Otherwise, just use the actual Feature collection in will_paginate
    else
      pagination_collection = features

--- a/lib/kmaps_engine/session_manager.rb
+++ b/lib/kmaps_engine/session_manager.rb
@@ -14,7 +14,7 @@ module KmapsEngine
     end
 
     def current_perspective
-      perspective_id = session[:perspective_id]
+      perspective_id = session['perspective_id']
       begin
         if perspective_id.blank?
           @@current_perspective = Perspective.get_by_code(default_perspective_code) if !defined?(@@current_perspect) || @@current_perspective.nil? || @@current_perspective.code != default_perspective_code
@@ -22,22 +22,22 @@ module KmapsEngine
           @@current_perspective = Perspective.find(perspective_id) if !defined?(@@current_perspect) || @@current_perspective.nil? || @@current_perspective.id != perspective_id
         end
       rescue ActiveRecord::RecordNotFound
-        session[:perspective_id] = nil
+        session['perspective_id'] = nil
         @@current_perspective = Perspective.get_by_code(default_perspective_code)
       end
       return @@current_perspective
     end
 
     def current_perspective=(perspective)
-      session[:perspective_id] = perspective.id
+      session['perspective_id'] = perspective.id
     end
 
     def current_perspective_id=(perspective_id)
-      session[:perspective_id] = perspective_id
+      session['perspective_id'] = perspective_id
     end
 
     def current_view
-      view_id = session[:view_id]
+      view_id = session['view_id']
       begin
         if view_id.blank?
           @@current_view = View.get_by_code(default_view_code) if !defined?(@@current_view) || @@current_view.nil? || @@current_view.code != default_view_code
@@ -45,34 +45,34 @@ module KmapsEngine
           @@current_view = View.find(view_id) if !defined?(@@current_view) || @@current_view.nil? || @@current_view.id != view_id
         end
       rescue ActiveRecord::RecordNotFound
-        session[:view_id] = nil
+        session['view_id'] = nil
         @@current_view = View.get_by_code(default_view_code)
       end
       return @@current_view
     end
 
     def current_view=(view)
-      session[:view_id] = view.id
+      session['view_id'] = view.id
     end
 
     def current_view_id=(view_id)
-      session[:view_id] = view_id
+      session['view_id'] = view_id
     end
 
     def current_show_advanced_search
-      session[:show_advanced_search].nil? ? false : session[:show_advanced_search]
+      session['show_advanced_search'].nil? ? false : session['show_advanced_search']
     end
 
     def current_show_advanced_search=(show_advanced_search)
-      session[:show_advanced_search] = ['true', true, '1', 1].include?(show_advanced_search) ? true : false
+      session['show_advanced_search'] = ['true', true, '1', 1].include?(show_advanced_search) ? true : false
     end
 
     def current_show_feature_details
-      session[:show_feature_details].nil? ? false : session[:show_feature_details]
+      session['show_feature_details'].nil? ? false : session['show_feature_details']
     end
 
     def current_show_feature_details=(show_feature_details)
-      session[:show_feature_details] = ['true', true, '1', 1].include?(show_feature_details) ? true : false
+      session['show_feature_details'] = ['true', true, '1', 1].include?(show_feature_details) ? true : false
     end
 
     # Inclusion hook to make #current_perspective

--- a/lib/kmaps_engine/version.rb
+++ b/lib/kmaps_engine/version.rb
@@ -1,3 +1,3 @@
 module KmapsEngine
-  VERSION = '5.7.1'
+  VERSION = '5.7.2'
 end


### PR DESCRIPTION
**Jira Issue:** MANU-6102

**Changes proposed in this pull request:**

 + Fix bug on `contextual_feature` accessing the sesison's `context_id`

**Details of the implementation:**

The session sometimes accesses the `context_id` as a symbol and sometimes
as a string. This was fixed by supporting both cases.

Updated engine version for merge.

