### PR TITLE
Adds Mandala Texts Integration to Kmaps as Essays for each Feature - MANU-6331

### DIFF
--- a/app/assets/javascripts/kmaps_engine/essays_admin.js
+++ b/app/assets/javascripts/kmaps_engine/essays_admin.js
@@ -1,0 +1,53 @@
+$(document).ready(function() {
+  var menuSolrUtils = kmapsSolrUtils.init({
+    assetIndex: $('#essay_js_data').data('assetIndex'),
+    featureId: $('#essay_js_data').data('featureId'),
+    domain: $('#essay_js_data').data('domain'),
+  });
+  var availableLanguages = $('#essay_js_data').data('availableLanguages');
+  var defaultLanguage = availableLanguages.find(({ code }) => code === 'eng')["id"];
+
+  var subjectsLanguages = $('#essay_js_data').data('mandalaMapLanguages');
+  //From the subjectsLanguages we are going to generate an array that contains only the subjects:
+  var railsLanguages = Object.keys(subjectsLanguages);
+
+  var result = menuSolrUtils.getRelatedMandalaTexts();
+  result.then(function(data){
+    var textOptionContainer = $("#mandala_text_options_js");
+    if (data.length == 0 ) {
+      textOptionContainer.html("You haven't labeled any texts using this "+
+        $('#essay_js_data').data('featureType')+
+        ". For help, see <a href='https://confluence.its.virginia.edu/display/KB/Join+Related+Resources'>this guide</a>.");
+      return;
+    }
+    var options = "<ul style='display:table'>";
+    var related = {};
+    data.forEach(function (text){
+      related[text["id"]] = text["related"];
+      var option = "<li>";
+      option += "<label><input type='radio' name='mandalaTextOption' value='"+text["id"]+"'> ";
+      option += text["title"]+"</label>";
+      option += "</li>";
+      options += option;
+    });
+    options += "</ul>";
+    textOptionContainer.html(options);
+    $('input:radio[name="mandalaTextOption"]').on('click', function(e) {
+      var textId = $('input:radio[name="mandalaTextOption"]:checked').val()
+      $("#text_id").val(textId);
+      var matchingLanguages = related[textId].filter((language) => railsLanguages.includes(language));
+      if (Array.isArray(matchingLanguages) && matchingLanguages.length) {
+        //We are going to use the first match as the default
+        var autoLanguage = subjectsLanguages[matchingLanguages[0]];
+        $("[name='essay[language_id]'] option[value="+autoLanguage+"]").attr('selected',true);
+      } else {
+        $("[name='essay[language_id]'] option[value="+defaultLanguage+"]").attr('selected',true);
+      }
+      $("[name='essay[language_id]']").change();
+    });
+    var currentTextId = $("#text_id").val();
+    if (!!currentTextId) {
+      $('input:radio[name="mandalaTextOption"][value='+currentTextId+']').attr('checked', true);
+    }
+  });
+});

--- a/app/assets/javascripts/kmaps_engine/kmaps-simple-typeahead.js
+++ b/app/assets/javascripts/kmaps_engine/kmaps-simple-typeahead.js
@@ -86,7 +86,7 @@
           prepare: function (query, remote) { //http://stackoverflow.com/questions/18688891/typeahead-js-include-dynamic-variable-in-remote-url
             var extras = {};
             var orig_val = input.val();
-            var val = orig_val.replace(/[\-\[\]\/\{\}\(\)\*\+\?\.\,\/\\\^\$\|]/g, " ");
+            var val = orig_val.replace(/[\:\-\[\]\/\{\}\(\)\*\+\?\.\,\/\\\^\$\|]/g, " ");
             switch(settings.match_criterion){
               case 'begins':
                 val = ""+val+"*";

--- a/app/assets/javascripts/kmaps_engine/solr-utils.js
+++ b/app/assets/javascripts/kmaps_engine/solr-utils.js
@@ -902,6 +902,44 @@
     return dfd.promise();
   }
 
+  Plugin.getRelatedMandalaTexts = function(){
+    var plugin = this;
+    var dfd = $.Deferred();
+    var relatedUrl =
+      plugin.settings.assetIndex + '/select?q=asset_type:texts* AND kmapid_strict:' + plugin.settings.domain+'-'+plugin.settings.featureId + '&wt=json&json.wrf=?';
+    $.ajax({
+      type: "GET",
+      url: relatedUrl,
+      dataType: "jsonp",
+      timeout: 90000,
+      error: function (e) {
+        console.error(e);
+      },
+      beforeSend: function () {
+      },
+      success: function (data) {
+        const response = data.response;
+        if(response.numFound > 0){
+          const result = response.docs.reduce(function(acc,currentNode,index){
+            var currentElement = {
+              id: currentNode["id"],
+              uid: currentNode["uid"],
+              title: currentNode["title"][0],
+              related: currentNode["kmapid_strict"]
+            };
+            var resultado = acc.concat([currentElement]);
+            return acc.concat([currentElement]);
+          }, []);
+          dfd.resolve(result);
+        } else {
+          dfd.resolve([]);
+        }
+      }
+    });
+    return dfd.promise();
+  };
+
+
   // END - Relations tree functions
   return Plugin;
 } )( jQuery, window, document );

--- a/app/assets/stylesheets/kmaps_engine/application.css
+++ b/app/assets/stylesheets/kmaps_engine/application.css
@@ -10,6 +10,7 @@
  *
  *= require_self
  *= require interface_utils/application
+ *= require kmaps_engine/essays
  *= require kmaps_engine/node-tree
  *= require kmaps_engine/main
  *= require kmaps_tree/kmapstree

--- a/app/assets/stylesheets/kmaps_engine/essays.css
+++ b/app/assets/stylesheets/kmaps_engine/essays.css
@@ -1,0 +1,10 @@
+.essays-form-fields input#text_title {
+    padding-left: 0;
+    width: 90%;
+}
+.essays-form-fields .row, .twitter-typeahead {
+ margin: 0 0 0.2rem 1rem;
+}
+.essays-form-fields .row {
+  padding-top: 10px;
+}

--- a/app/controllers/admin/essays_controller.rb
+++ b/app/controllers/admin/essays_controller.rb
@@ -1,0 +1,28 @@
+class Admin::EssaysController < AclController
+  include KmapsEngine::ResourceObjectAuthentication
+  resource_controller
+
+  belongs_to :feature
+  protected
+
+  new_action.before do
+    @languages = Language.available_as_locales
+  end
+
+  edit.before do
+    @languages = Language.available_as_locales
+  end
+  
+  create.before do
+    @languages = Language.available_as_locales
+  end
+  
+  update.before do
+    @languages = Language.available_as_locales
+  end
+
+  # Only allow a trusted parameter "white list" through.
+  def essay_params
+    params.require(:essay).permit(:feature_id, :text_id, :language_id)
+  end
+end

--- a/app/models/essay.rb
+++ b/app/models/essay.rb
@@ -1,0 +1,11 @@
+class Essay < ApplicationRecord
+  validates_presence_of :feature_id
+  validates_presence_of :text_id
+  
+  belongs_to :feature
+  belongs_to :language
+  
+  def text
+    ShantiIntegration::Text.find(self.text_id)
+  end
+end

--- a/app/models/feature.rb
+++ b/app/models/feature.rb
@@ -40,6 +40,7 @@ class Feature < ActiveRecord::Base
   has_many :collections, through: :affiliations
   has_many :citations, as: :citable, dependent: :destroy
   has_many :descriptions, dependent: :destroy
+  has_many :essays, dependent: :destroy
   has_many :geo_codes, class_name: 'FeatureGeoCode', dependent: :destroy # naming inconsistency here (see feature_object_types association) ?
   has_many :geo_code_types, through: :geo_codes
   has_many :illustrations, dependent: :destroy
@@ -573,6 +574,10 @@ class Feature < ActiveRecord::Base
       end
       doc["caption_#{c.language.code}_#{c.id}_content_t"] = c.content
       doc["caption_#{c.language.code}_#{c.id}_citation_references_ss"] = c.citations.collect { |ci| ci.info_source.bibliographic_reference }
+    end
+    mandala_text_mapping = Language.mandala_text_mappings.invert
+    self.essays.each do |e|
+      doc["homepage_text_#{mandala_text_mapping[e.language.id]}_s"] = e.text_id
     end
     self.summaries.each do |s|
       if doc["summary_#{s.language.code}"].blank?

--- a/app/models/language.rb
+++ b/app/models/language.rb
@@ -56,6 +56,20 @@ class Language < SimpleProp
     self.find_by(['code LIKE ?', "#{I18n.locale}%"])
   end
 
+  def self.available_as_locales
+    self.where("code ILIKE ANY ( array[?] )", I18n.available_locales.map {|loc| "#{loc}%"}).order('name')
+  end
+
+  def self.mandala_text_mappings
+    @@mandala_text_lang ||= {
+      "subjects-570"   => self.find_by(['code LIKE ?', "eng"]).id,
+      "subjects-676"   => self.find_by(['code LIKE ?', "dzo"]).id,
+      "subjects-9237"  => self.find_by(['code LIKE ?', "zho"]).id,
+      "subjects-638"   => self.find_by(['code LIKE ?', "bod"]).id,
+      "subjects-4233"  => self.find_by(['code LIKE ?', "bod"]).id
+    }
+  end
+
   def lacks_transcription_system?
     Language.lacks_transcription_system_id? self.id
   end

--- a/app/views/admin/essays/_form_fields.html.erb
+++ b/app/views/admin/essays/_form_fields.html.erb
@@ -1,0 +1,40 @@
+<div class="essays-form-fields">
+<% if object.errors.any? %>
+    <div id="error_explanation">
+      <h2><%= pluralize(object.errors.count, "error") %> prohibited this essay from being saved:</h2>
+
+      <ul>
+        <% object.errors.full_messages.each do |message| %>
+          <li><%= message %></li>
+        <% end %>
+      </ul>
+    </div>
+<% end %>
+<fieldset>
+  <legend><%= ts(:for, what: t('information.general'), whom: Essay.model_name.human.titleize) %></legend>
+  <div class="row">
+    <%= form.label :text_title, Essay.model_name.human.titleize %>
+    <br/>
+    <br/>
+    <%= form.hidden_field :text_id, id: :text_id %>
+    <p>Select one of the texts associated with this <%= Feature.model_name.human %>:</p>
+  </div>
+  <div class="row" id="mandala_text_options_js">
+    <p>Loading Associated Texts...</p>
+  </div>
+  <br class="clear"/>
+  <p><b><%= form.label :language_id, Language.model_name.human.titleize.s %></b></p><br/>
+  <div class="row">
+  <%= form.collection_select :language_id, @languages, :id, :to_s, {include_blank: false}, class: 'form-control form-select ss-select selectpicker' %>
+  </div>
+</fieldset>
+</div> <!-- END - subject-term-associations-form-fields -->
+<%= content_tag :div, '', id: 'essay_js_data', data: {
+ asset_index: ShantiIntegration::Text.config.url,
+ feature_id: object.feature.fid,
+ domain: Feature.uid_prefix,
+ feature_type: Feature.model_name.human,
+ available_languages: Language.available_as_locales.map { |l| {code: l.code, id: l.id} },
+ mandala_map_languages: Language.mandala_text_mappings
+} %>
+<%= javascript_include_tag 'kmaps_engine/essays_admin' %>

--- a/app/views/admin/essays/_list.html.erb
+++ b/app/views/admin/essays/_list.html.erb
@@ -1,0 +1,22 @@
+<% if list.empty? %>
+<%= empty_collection_message "No #{Essay.model_name.human(:count => :many).titleize} found." %>
+<% else %>
+   <table class="listGrid">
+     <tr>
+       <th class="listActionsCol"></th>
+       <th><%= Essay.model_name.human.titleize.s %></th>
+       <th><%= Essay.human_attribute_name('title')%></th>
+     </tr>
+<%   list.each do |item| %>
+     <tr>
+       <td class="centerText">
+<%=      list_actions_for_item(item, :delete_path => admin_feature_essay_path(item.feature, item),
+         :edit_path => edit_admin_feature_essay_path(item.feature, item),
+         :view_path => admin_feature_essay_path(item.feature, item)) %>
+       </td>
+       <td><%= item.text_id %></td>
+       <td><%= item.text.title %></td>
+     </tr>
+   <%   end %>
+   </table>
+ <% end %>

--- a/app/views/admin/essays/edit.html.erb
+++ b/app/views/admin/essays/edit.html.erb
@@ -1,0 +1,18 @@
+<% add_breadcrumb_item feature_link(object.feature)
+   add_breadcrumb_item link_to 'essays', admin_feature_essays_path(object.feature)
+   add_breadcrumb_item object.id %>
+<section class="panel panel-content">
+  <div class="panel-heading">
+    <h6>Editing <%= Essay.model_name.human.titleize.s %></h6>
+  </div>
+  <div class="panel-body">
+    <%= form_with(model: [:admin, object.feature, object], local: true) do |form| %>
+      <%=  render partial: 'form_fields', locals: {form: form} %>
+      <div class="actions">
+      <%=  link_to ts('cancel.this'), admin_feature_path(object.feature.fid) , class: 'btn btn-primary form-submit', id: 'edit-cancel' %> |
+      <%= globalized_submit_tag 'update.this', class: 'btn btn-primary form-submit' %>
+      </div>
+    <% end %>
+  </div> <!-- END panel-body -->
+</section> <!-- END panel -->
+

--- a/app/views/admin/essays/index.html.erb
+++ b/app/views/admin/essays/index.html.erb
@@ -1,0 +1,9 @@
+<% add_breadcrumb_item feature_link(parent_object) %>
+<section class="panel panel-content">
+  <div class="panel-heading">
+    <h6><%= Essay.model_name.human.pluralize.titleize.s %></h6>
+  </div>
+  <div class="panel-body">
+<%=       render :partial => 'admin/essays/list', :locals => { :list => parent_object.essays } %>
+  </div> <!-- END panel-body -->
+</section> <!-- END panel -->

--- a/app/views/admin/essays/new.html.erb
+++ b/app/views/admin/essays/new.html.erb
@@ -1,0 +1,19 @@
+<% 
+add_breadcrumb_item feature_link(object.feature)
+add_breadcrumb_item link_to Essay.model_name.human(count: :many).titleize.s, admin_feature_essays_path(object.feature)
+add_breadcrumb_item ts('new.this')
+%>
+<div><h1><%= ts :for, what: t('creat.ing', what: t('new.record', what: Essay.model_name.human.titleize)), whom: "#{Feature.model_name.human.titleize} #{parent_object}" %></h1></div>
+<br class="clear"/>
+<%= form_with(model: [:admin, object.feature, object], local: true) do |form| %>
+  <section class="panel panel-content">
+    <div class="panel-heading">
+      <h6><%= Essay.model_name.human.titleize.s %></h6>
+    </div>
+    <div class="panel-body">
+      <%=  render partial: 'form_fields', locals: {form: form} %>
+      <%=  link_to ts('cancel.this'), admin_feature_path(object.feature.fid) , class: 'btn btn-primary form-submit', id: 'edit-cancel' %> |
+      <%=  globalized_submit_tag 'creat.e.this', class: 'submit btn btn-primary form-submit' %>
+    </div> <!-- END panel-body -->
+  </section> <!-- END panel -->
+<% end %>

--- a/app/views/admin/essays/show.html.erb
+++ b/app/views/admin/essays/show.html.erb
@@ -1,0 +1,24 @@
+<% add_breadcrumb_item feature_link(object.feature)
+   add_breadcrumb_item link_to 'essays', admin_feature_essays_path(object.feature)
+%>
+<section class="panel panel-content">
+  <div class="panel-heading">
+     <h6><%= Essay.model_name.human.titleize.s %></h6>
+  </div>
+  <div class="panel-body">
+    <p id="notice"><%= notice %></p>
+
+    <p>
+    <strong>Text ID:</strong>
+    <%= object.text_id %>
+    </p>
+
+    <p>
+    <strong><%= Essay.human_attribute_name(:title).s %></strong>
+    <%= object.text.title %>
+    </p>
+
+     <%= link_to ts('edit.this'), edit_admin_feature_essay_path(object.feature,object), class: 'btn btn-primary form-submit' %> |
+     <%=  link_to ts('cancel.this'), admin_feature_path(object.feature.fid), class: 'btn btn-primary form-submit', id: 'edit-cancel' %>
+  </div> <!-- END panel-body -->
+ </section> <!-- END panel -->

--- a/app/views/admin/features/show.html.erb
+++ b/app/views/admin/features/show.html.erb
@@ -142,14 +142,15 @@
 <%  end %>
     <section class="panel panel-default">
       <div class="panel-heading">
-        <h6><a href="#collapseNine" data-toggle="collapse" data-parent="#accordion" class="accordion-toggle collapsed"><span class="glyphicon glyphicon-plus"></span><%= Description.model_name.human(:count => :many).titleize.s %></a></h6>
+        <h6><a href="#collapseNine" data-toggle="collapse" data-parent="#accordion" class="accordion-toggle collapsed"><span class="glyphicon glyphicon-plus"></span><%= Essay.model_name.human(:count => :many).titleize.s %></a></h6>
       </div>
       <div id="collapseNine" class="panel-collapse collapse">
         <div class="panel-body">
-<%=       highlighted_new_item_link [object, :description] %>
+          <p>Homepage texts appear on the main overview place for the <%= Feature.model_name.human %>. Add texts to Mandala Texts first; see <a href="https://confluence.its.virginia.edu/display/KB/Texts+in+Mandala">this guide</a> for help. Homepage texts also need to be labeled using the <%= Feature.model_name.human %>; see <a href="https://confluence.its.virginia.edu/display/KB/Join+Related+Resources">this guide</a> for help.</p>
           <br class="clear"/>
-<%=       render :partial => 'admin/descriptions/descriptions_list', :locals => { :list => object.descriptions.order('is_primary DESC, title') } %>
-<%=       association_note_list_fieldset(Description.name) %>
+<%=       highlighted_new_item_link [object, :essay], ts('new.record', what: t(Essay.model_name.human.titleize.s, count: 1)) %>
+          <br class="clear"/>
+<%=       render :partial => 'admin/essays/list', :locals => { :list => object.essays } %>
     </div> <!-- END panel-body -->
   </div> <!-- END collapseNine -->
 </section>

--- a/app/views/features/_feature.html.erb
+++ b/app/views/features/_feature.html.erb
@@ -59,6 +59,15 @@
 <%      end %>
       </div> <!-- END resource-overview-image -->
 <%  end %>
+<% current_essay = feature.essays.where(language: Language.current).first
+   if !current_essay.nil? %>
+ <div class="feature_essay">
+   <% essay_content = current_essay.text.content
+      if !essay_content.blank? %>
+   <%= essay_content.html_safe %>
+   <% end %>
+ </div>
+<% end %>
 <div id="accordion" class="panel-group">
   <section class="panel panel-default">
     <div class="panel-heading">

--- a/config/initializers/assets.rb
+++ b/config/initializers/assets.rb
@@ -1,0 +1,1 @@
+Rails.application.config.assets.precompile.concat(['kmaps_engine/essays_admin.js'])

--- a/config/locales/bo/models.yml
+++ b/config/locales/bo/models.yml
@@ -30,6 +30,9 @@ bo:
             description:
                 one: 'རྩོམ་ཡིག'
                 other: 'རྩོམ་ཡིག'
+            essay:
+                one: 'homepage text'
+                other: 'homepage texts'
             external_picture:
                 one: 'external picture'
                 other: 'external pictures'
@@ -92,6 +95,9 @@ bo:
             description:
                 content: 'ཁ་བྱང་།'
                 is_primary: 'གཙོ་བོ་ཡིན།'
+                title: 'རྩོམ་ཡིག་གི་ཁ་བྱང་།'
+            essay:
+                content: 'ཁ་བྱང་།'
                 title: 'རྩོམ་ཡིག་གི་ཁ་བྱང་།'
             external_picture:
                 place_id: 'Place (Places Dictionary FID)'

--- a/config/locales/dz/models.yml
+++ b/config/locales/dz/models.yml
@@ -30,6 +30,9 @@ dz:
             description:
                 one: 'essay'
                 other: 'essays'
+            essay:
+                one: 'homepage text'
+                other: 'homepage texts'
             external_picture:
                 one: 'external picture'
                 other: 'external pictures'
@@ -92,6 +95,9 @@ dz:
             description:
                 content: 'Content'
                 is_primary: 'Primary?'
+                title: 'Essay Title'
+            essay:
+                content: 'Content'
                 title: 'Essay Title'
             external_picture:
                 place_id: 'Place (Places Dictionary FID)'

--- a/config/locales/en/models.yml
+++ b/config/locales/en/models.yml
@@ -30,6 +30,9 @@ en:
             description:
                 one: 'essay'
                 other: 'essays'
+            essay:
+                one: 'homepage text'
+                other: 'homepage texts'
             external_picture:
                 one: 'external picture'
                 other: 'external pictures'
@@ -93,6 +96,9 @@ en:
                 content: 'Content'
                 is_primary: 'Primary?'
                 title: 'Essay Title'
+            essay:
+                content: 'Content'
+                title: 'Title'
             external_picture:
                 place_id: 'Place (Places Dictionary FID)'
             feature_geo_code:

--- a/config/locales/zh/models.yml
+++ b/config/locales/zh/models.yml
@@ -30,6 +30,9 @@ zh:
             description:
                 one: '文章'
                 other: '文章'
+            essay:
+                one: 'homepage text'
+                other: 'homepage texts'
             external_picture:
                 one: 'external picture'
                 other: 'external pictures'
@@ -92,6 +95,9 @@ zh:
             description:
                 content: '题目'
                 is_primary: '是主要的'
+                title: '文章标题'
+            essay:
+                content: '题目'
                 title: '文章标题'
             external_picture:
                 place_id: 'Place (Places Dictionary FID)'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -51,7 +51,7 @@ Rails.application.routes.draw do
       collection do
         get 'prioritize_feature_names/:id', to: 'feature_names#prioritize', as: :prioritize_feature_names
       end
-      resources :captions, :feature_geo_codes, :feature_names, :feature_relations, :illustrations, :summaries
+      resources :captions, :essays, :feature_geo_codes, :feature_names, :feature_relations, :illustrations, :summaries
       resources :association_notes, concerns: :add_author
       resources :descriptions, concerns: :add_author
     end

--- a/db/migrate/20200512175610_create_essays.rb
+++ b/db/migrate/20200512175610_create_essays.rb
@@ -1,0 +1,10 @@
+class CreateEssays < ActiveRecord::Migration[5.2]
+  def change
+    create_table :essays do |t|
+      t.references :feature, foreign_key: true, null: false
+      t.integer :text_id, null: false
+      t.integer :language_id, null: false
+      t.timestamps
+    end
+  end
+end

--- a/lib/kmaps_engine/version.rb
+++ b/lib/kmaps_engine/version.rb
@@ -1,3 +1,3 @@
 module KmapsEngine
-  VERSION = '5.8.9'
+  VERSION = '5.9.0'
 end


### PR DESCRIPTION

**Jira Issue:** MANU-6331

**Changes proposed in this pull request:**

 + Add Essays to Editorial Interface
 + Display linked essay for Feature on view mode.

**Details of the implementation:**

Previously we had Descriptions presented to the User as Essays, that was
supposed to be migrated to Mandala Texts. Now we are creating a new
Essay model that will be linked to Mandala Texts through
`ShantiIntegration`. This essays are going to be used to display a more
descriptive text for each Feature.

The Essay is tied up to the current Language. So a Feature could have
many Essays with different languages. When the Feature is displayed we
are going to show the Essay for the language currently selected by the
user in view mode.
