### PR TITLE
Adds Hometext language selector on frontend - MANU-6427

### DIFF
--- a/app/views/admin/essays/_list.html.erb
+++ b/app/views/admin/essays/_list.html.erb
@@ -6,6 +6,7 @@
        <th class="listActionsCol"></th>
        <th><%= Essay.model_name.human.titleize.s %></th>
        <th><%= Essay.human_attribute_name('title')%></th>
+       <th><%= Language.model_name.human.titleize.s%></th>
      </tr>
 <%   list.each do |item| %>
      <tr>
@@ -16,6 +17,7 @@
        </td>
        <td><%= item.text_id %></td>
        <td><%= item.text.title %></td>
+       <td><%= item.language %></td>
      </tr>
    <%   end %>
    </table>

--- a/app/views/features/_feature.html.erb
+++ b/app/views/features/_feature.html.erb
@@ -59,9 +59,24 @@
 <%      end %>
       </div> <!-- END resource-overview-image -->
 <%  end %>
-<% current_essay = feature.essays.where(language: Language.current).first
+<%
+    essays = feature.essays
+    current_language = Language.current
+    if !essays.empty?
+%>
+  <div class="hometext-menu">
+    <%
+    essay_languages = feature.essays.select(:language_id).distinct.collect {|e| e.language }
+   %>
+   <%= label_tag(:language_language_id,"View home page text for specific language:") %>
+   <%= select_tag(:language_language_id, options_for_select(feature.essays.collect { |e| [e.language.name, e.text_id] })) %>
+  </div>
+<%
+    end
+%>
+<% current_essay = feature.essays.where(language: current_language).first
    if !current_essay.nil? %>
- <div class="feature_essay">
+ <div id="feature_essay">
    <% essay_content = current_essay.text.content
       if !essay_content.blank? %>
    <%= essay_content.html_safe %>
@@ -115,4 +130,17 @@
       jQuery('[data-js-kmaps-popup]').kmapsPopup({
         type: POPUP_TYPE_INFO,
       });
+      <% if !current_essay.nil? %>
+        $("#language_language_id").val("<%= current_essay.text_id %>");
+        $("#language_language_id").change(function(e){
+          console.log($(this).val());
+          var text_id = $(this).val();
+          $.ajax({
+          url: "https://texts-dev.shanti.virginia.edu/shanti_texts/node_ajax/"+text_id,
+          dataType: "jsonp",
+          }).done(function(data){
+          $("#feature_essay").html(data);
+          });
+        });
+      <% end %>
 <%  end %>

--- a/lib/kmaps_engine/version.rb
+++ b/lib/kmaps_engine/version.rb
@@ -1,3 +1,3 @@
 module KmapsEngine
-  VERSION = '5.9.7'
+  VERSION = '5.9.8'
 end


### PR DESCRIPTION
**Jira Issue:** MANU-6427

**Changes proposed in this pull request:**

 + Add language column to Essays on the editorial interface.
 + Add a dropdown to display Mandala Home pages associated to different languages on user frontend.

**Details of the implementation:**

Added a dropdown on the features user frontend when the features have an associated Essay(Mandala Hometext). We need to work on our frontend design. Currently is only a simple text and dropdown.
