### PR TITLE
Fixed capitalization of names in breadcrumbs in view and edit mode

### DIFF
--- a/app/assets/stylesheets/kmaps_engine/application.css
+++ b/app/assets/stylesheets/kmaps_engine/application.css
@@ -41,3 +41,8 @@ div.row.row-offcanvas.row-offcanvas-left { margin-left: 0px; margin-right: 0px; 
     background: #fafafa;
     color: #555;
 }
+
+/* The class non-capitalizable is applied when content should not be capitalized, e.g. for names in ortographic transliterations. */
+.breadcrumb li .non-capitalizable {
+  text-transform: none;
+}

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -43,8 +43,14 @@ module ApplicationHelper
       ancestors_list ||= @feature.closest_ancestors_by_perspective(current_perspective)
       list = ancestors_list.collect do |r|
         name = r.prioritized_name(current_view)
-        name = name.nil? ? r.pid : name.name
-        link_to(name, feature_path(r.fid))
+        options = {}
+        if name.nil?
+          name_str = r.pid
+        else
+          name_str = name.name
+          options[:class] = 'non-capitalizable' if !name.orthographic_system_code.blank?
+        end
+        link_to(name_str, feature_path(r.fid), options)
       end
       list = [link_to("#{ts('app.short')}:".html_safe, root_path)] + list[0...list.size-1].collect{|e| "#{e}#{breadcrumb_separator}".html_safe} + [list.last]
       content_tag :ol, list.collect{|e| "<li>#{e}</li>"}.join.html_safe, class: 'breadcrumb'
@@ -151,8 +157,10 @@ module ApplicationHelper
   end
 
   def fname_label(feature_name)
-    css_class=feature_name.writing_system.nil? ? nil : feature_name.writing_system.code
-    content_tag(:span, h(feature_name.to_s), {:class=>css_class})
+    css_classes = []
+    css_classes << feature_name.writing_system.code if !feature_name.writing_system.nil?
+    css_classes << 'non-capitalizable' if !feature_name.orthographic_system_code.blank?
+    content_tag(:span, h(feature_name.to_s), { class: css_classes.join(' ') })
   end
 
   def description_title(d)

--- a/app/models/feature_name.rb
+++ b/app/models/feature_name.rb
@@ -100,6 +100,13 @@ class FeatureName < ActiveRecord::Base
     r.code
   end
   
+  def orthographic_system_code
+    r = parent_relations.first
+    return nil if r.nil?
+    o = r.orthographic_system
+    return o.nil? ? nil : o.code
+  end
+  
   def display_string
     return 'Original' if is_original?
     parent_relations.first.display_string

--- a/lib/kmaps_engine/version.rb
+++ b/lib/kmaps_engine/version.rb
@@ -1,3 +1,3 @@
 module KmapsEngine
-  VERSION = '6.0.0'
+  VERSION = '6.0.1'
 end


### PR DESCRIPTION
**Jira Issue:** MANU-6250

**Changes proposed in this pull request:**

 + Added class "non-capitalizable" in link and span of breadcrumbs for css rendering
 + Determined if that a name is non capitalizable when it is an orthographic transliteration of another name (for example tibetan wylie)

**Details of the implementation:**

Certain names should be and certain names should not be capitalized in breadcrumbs. This applies to subjects, places and terms. To calculate which, a method was added to feature_name model and used within helpers involved in breadcrumb generation.
