### PR TITLE
Fixes bug when predicate field is missing - MANU-6532

### DIFF
--- a/app/assets/javascripts/kmaps_engine/solr-utils.js
+++ b/app/assets/javascripts/kmaps_engine/solr-utils.js
@@ -641,7 +641,7 @@
                   marks.push(marker['mark']);
                 }
               } else if(marker['operation'] == '!includes') {
-                if (!currentNode[marker['field']].includes(marker['value'])) {
+                if (currentNode[marker['field']] && !currentNode[marker['field']].includes(marker['value'])) {
                   marks.push(marker['mark']);
                 }
               } else if(marker['operation'] == 'markAll') {


### PR DESCRIPTION
**Jira Issue:** MANU-6532

**Changes proposed in this pull request:**

 + Fix error on SolrUtils caused by missing field referenced in Predicate marking statement.

**Details of the implementation:**

When opening Terms the flyout tree fails due to missing field when `associated_subject_ids` has not been reindexed. This is due to the NodeMarkerPredicates expecting `associated_subjects_ids` to exist.

This shouldn't be a normal occurance, because all nodes should be
indexed, but it might happen when nodes are newly added.