### PR TITLE
MANU-7776 combine notes/dates columns

### DIFF
--- a/app/helpers/admin_helper.rb
+++ b/app/helpers/admin_helper.rb
@@ -312,10 +312,8 @@ module AdminHelper
       html += '<td>' + def_if_blank(name, :writing_system).to_s + '</td>'
       html += '<td>' + fn_relationship(name).to_s + '</td>'
       html += '<td>' + name.position.to_s + '</td>'
-      html += '<td>' + note_link_list_for(name) + '</td>'
-      html += '<td>' + new_note_link_for(name) + '</td>'
-      html += '<td>' + time_unit_link_list_for(name) + '</td>'
-      html += '<td>' + new_time_unit_link_for(name) + '</td>'
+      html += '<td>' + note_link_list_for(name) + new_note_link_for(name) + '</td>'
+      html += '<td>' + time_unit_link_list_for(name) + new_time_unit_link_for(name) + '</td>'
       html += '</tr>'
       html += feature_name_tr(nil, name.children, completed).to_s
     end

--- a/app/views/admin/feature_names/_feature_names.html.erb
+++ b/app/views/admin/feature_names/_feature_names.html.erb
@@ -11,9 +11,7 @@
        <th><%= ts 'relat.ion.ship.this' %></th>
        <th><%= ts 'priorit.y' %></th>
        <th><%= Note.model_name.human(:count => :many).titleize.s %></th>
-       <th><%= ts 'add.record', :what => Note.model_name.human.titleize %></th>
        <th><%= t('date.this', :count => :many).titleize.s.s %></th>
-       <th><%= ts 'add.record', :what => t('date.this', :count => 1).titleize %></th>
      </tr>
 <%= pagination_row :colspan=>8 unless @collection.nil? %>
 <%= feature_name_tr(@feature) %>

--- a/app/views/admin/feature_relations/_list.html.erb
+++ b/app/views/admin/feature_relations/_list.html.erb
@@ -10,9 +10,7 @@
        <th><%= FeatureRelation.model_name.human.titleize.s %></th>
        <th><%= Perspective.model_name.human.titleize.s %></th>
        <th><%= Note.model_name.human(:count => :many).titleize.s %></th>
-       <th><%= ts 'add.record', :what => Note.model_name.human.titleize %></th>
        <th><%= t('date.this', :count => :many).titleize.s %></th>
-       <th><%= ts 'add.record', :what => t('date.this', :count => 1).titleize %></th>
      </tr>
 <%   list.each do |item| %>
      <tr>   
@@ -39,10 +37,8 @@
 <%     end %>
        </td>
        <td><%= item.perspective %></td>
-       <td><%= note_link_list_for item %></td>
-       <td><%= new_note_link_for item %></td>
-       <td><%= time_unit_link_list_for item %></td>
-       <td><%= new_time_unit_link_for item %></td>
+       <td><%= note_link_list_for item %> <%= new_note_link_for item %></td>
+       <td><%= time_unit_link_list_for item %> <%= new_time_unit_link_for item %></td>
      </tr>
 <%   end %>
    </table>


### PR DESCRIPTION
MANU-7776 (https://uvaissues.atlassian.net/browse/MANU-7776)

Currently, in the accordion under some sections (TERM RELATIONS and NAMES sections),
 there are tables that have four columns as follows:
Notes | Add Note | Dates | Add Dates

Combine the data **Notes** and **Add Note** under one heading "**Notes**" in one column
Combine the data **Dates** and **Add Date** under one heading "**Dates**" in one column

This change was requested via this document:
https://docs.google.com/document/d/1TwkQ02IK7vM_7wfq6ZoNZeyMbDZxOxzP16VvNIHuJHs/edit
