### PR TITLE
MANU-7806 move priority column to end of table, align change priority…

### DIFF
--- a/app/assets/stylesheets/kmaps_engine/admin.css
+++ b/app/assets/stylesheets/kmaps_engine/admin.css
@@ -473,3 +473,11 @@ input.text-full {
 #search-flyout input[type=text]{
   width: inherit;
 }
+
+/* container for links above tables */
+.flexContainer {
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display:flex;
+  justify-content: space-between;
+}

--- a/app/helpers/admin_helper.rb
+++ b/app/helpers/admin_helper.rb
@@ -311,11 +311,11 @@ module AdminHelper
       html += '<td>' + def_if_blank(name, :language).to_s + '</td>'
       html += '<td>' + def_if_blank(name, :writing_system).to_s + '</td>'
       html += '<td>' + fn_relationship(name).to_s + '</td>'
-      html += '<td>' + name.position.to_s + '</td>'
       html += '<td>' + note_link_list_for(name) + '</td>'
       html += '<td>' + new_note_link_for(name) + '</td>'
       html += '<td>' + time_unit_link_list_for(name) + '</td>'
       html += '<td>' + new_time_unit_link_for(name) + '</td>'
+      html += '<td>' + name.position.to_s + '</td>'
       html += '</tr>'
       html += feature_name_tr(nil, name.children, completed).to_s
     end

--- a/app/views/admin/feature_names/_feature_names.html.erb
+++ b/app/views/admin/feature_names/_feature_names.html.erb
@@ -9,11 +9,11 @@
        <th><%= Language.model_name.human.titleize.s %></th>
        <th><%= WritingSystem.model_name.human.titleize.s %></th>
        <th><%= ts 'relat.ion.ship.this' %></th>
-       <th><%= ts 'priorit.y' %></th>
        <th><%= Note.model_name.human(:count => :many).titleize.s %></th>
        <th><%= ts 'add.record', :what => Note.model_name.human.titleize %></th>
        <th><%= t('date.this', :count => :many).titleize.s.s %></th>
        <th><%= ts 'add.record', :what => t('date.this', :count => 1).titleize %></th>
+       <th><%= ts 'priorit.y' %></th>
      </tr>
 <%= pagination_row :colspan=>8 unless @collection.nil? %>
 <%= feature_name_tr(@feature) %>


### PR DESCRIPTION
**MANU-7806:** [https://uvaissues.atlassian.net/browse/MANU-7806]

Show priority at end of table and align 'change priority' link above it under Names

This pull request must be merged and deployed at the same time as this pull request to the terms engine gem.
https://github.com/shanti-uva/terms_engine/pull/73

This change was requested via this document:
https://docs.google.com/document/d/1TwkQ02IK7vM_7wfq6ZoNZeyMbDZxOxzP16VvNIHuJHs/edit
