### PR TITLE
MANU-7789 show appropriate section name in empty collection message

### DIFF
--- a/app/views/admin/captions/_list.html.erb
+++ b/app/views/admin/captions/_list.html.erb
@@ -1,5 +1,5 @@
 <% if list.empty? %>
-<%=  empty_collection_message %>
+<%=  empty_collection_message("No #{Caption.model_name.human(count: :many).titleize.s} found.") %>
 <% else %>
    <table class="listGrid">
      <tr>

--- a/app/views/admin/captions/_list.html.erb
+++ b/app/views/admin/captions/_list.html.erb
@@ -1,5 +1,5 @@
 <% if list.empty? %>
-<%=  empty_collection_message("No #{Caption.model_name.human(count: :many).titleize.s} found.") %>
+<%=  empty_collection_message("No #{Caption.model_name.human(count: :many).s} found.") %>
 <% else %>
    <table class="listGrid">
      <tr>

--- a/app/views/admin/descriptions/_descriptions_list.html.erb
+++ b/app/views/admin/descriptions/_descriptions_list.html.erb
@@ -1,5 +1,5 @@
 <% if list.empty? %>
-<%=  empty_collection_message %>
+<%=  empty_collection_message("No #{Description.model_name.human(count: :many).titleize.s} found.") %>
 <% else %>
      <table class="listGrid">
 <%=    pagination_row :colspan=>6 unless @collection.nil? %>

--- a/app/views/admin/descriptions/_descriptions_list.html.erb
+++ b/app/views/admin/descriptions/_descriptions_list.html.erb
@@ -1,5 +1,5 @@
 <% if list.empty? %>
-<%=  empty_collection_message("No #{Description.model_name.human(count: :many).titleize.s} found.") %>
+<%=  empty_collection_message("No #{Description.model_name.human(count: :many).s} found.") %>
 <% else %>
      <table class="listGrid">
 <%=    pagination_row :colspan=>6 unless @collection.nil? %>

--- a/app/views/admin/essays/_list.html.erb
+++ b/app/views/admin/essays/_list.html.erb
@@ -1,5 +1,5 @@
 <% if list.empty? %>
-<%= empty_collection_message "No #{Essay.model_name.human(:count => :many).titleize} found." %>
+<%= empty_collection_message "No #{Essay.model_name.human(:count => :many).s} found." %>
 <% else %>
    <table class="listGrid">
      <tr>

--- a/app/views/admin/feature_geo_codes/_list.html.erb
+++ b/app/views/admin/feature_geo_codes/_list.html.erb
@@ -1,5 +1,5 @@
 <% if list.empty? %>
-<%=  empty_collection_message %>
+<%=  empty_collection_message("No #{FeatureGeoCode.model_name.human(count: :many).titleize.s} found.") %>
 <% else %>
    <table class="listGrid">
 <%=  pagination_row :colspan=>7 unless @collection.nil? %>

--- a/app/views/admin/feature_geo_codes/_list.html.erb
+++ b/app/views/admin/feature_geo_codes/_list.html.erb
@@ -1,5 +1,5 @@
 <% if list.empty? %>
-<%=  empty_collection_message("No #{FeatureGeoCode.model_name.human(count: :many).titleize.s} found.") %>
+<%=  empty_collection_message("No #{FeatureGeoCode.model_name.human(count: :many).s} found.") %>
 <% else %>
    <table class="listGrid">
 <%=  pagination_row :colspan=>7 unless @collection.nil? %>

--- a/app/views/admin/feature_relation_types/_list.html.erb
+++ b/app/views/admin/feature_relation_types/_list.html.erb
@@ -1,6 +1,6 @@
 <% list = list || [] 
    if list.empty? %>
-<%=  empty_collection_message %>
+<%=  empty_collection_message("No #{FeatureRelationType.model_name.human(count: :many).titleize.s} found.") %>
 <% else %>
    <table class="listGrid">
 <%=  pagination_row :colspan=>3 unless @collection.nil? %>

--- a/app/views/admin/feature_relation_types/_list.html.erb
+++ b/app/views/admin/feature_relation_types/_list.html.erb
@@ -1,6 +1,6 @@
 <% list = list || [] 
    if list.empty? %>
-<%=  empty_collection_message("No #{FeatureRelationType.model_name.human(count: :many).titleize.s} found.") %>
+<%=  empty_collection_message("No #{FeatureRelationType.model_name.human(count: :many).s} found.") %>
 <% else %>
    <table class="listGrid">
 <%=  pagination_row :colspan=>3 unless @collection.nil? %>

--- a/app/views/admin/feature_relations/_list.html.erb
+++ b/app/views/admin/feature_relations/_list.html.erb
@@ -1,7 +1,7 @@
 <% use_first = use_first.nil? ? true : use_first
    use_names = use_names.nil? ? false : use_names
    if list.empty? %>
-<%=  empty_collection_message %>
+<%=  empty_collection_message("No #{FeatureRelation.model_name.human(count: :many).titleize.s} found.") %>
 <% else %>
    <table class="listGrid">
 <%=  pagination_row :colspan=>6 unless @collection.nil? %>

--- a/app/views/admin/feature_relations/_list.html.erb
+++ b/app/views/admin/feature_relations/_list.html.erb
@@ -1,7 +1,7 @@
 <% use_first = use_first.nil? ? true : use_first
    use_names = use_names.nil? ? false : use_names
    if list.empty? %>
-<%=  empty_collection_message("No #{FeatureRelation.model_name.human(count: :many).titleize.s} found.") %>
+<%=  empty_collection_message("No #{FeatureRelation.model_name.human(count: :many).s} found.") %>
 <% else %>
    <table class="listGrid">
 <%=  pagination_row :colspan=>6 unless @collection.nil? %>

--- a/app/views/admin/illustrations/_list.html.erb
+++ b/app/views/admin/illustrations/_list.html.erb
@@ -1,5 +1,5 @@
 <% if list.empty? %>
-<%=  empty_collection_message %>
+<%=  empty_collection_message("No #{Illustration.model_name.human(count: :many).titleize.s} found.") %>
 <% else %>
    <table class="listGrid">
      <tr>

--- a/app/views/admin/illustrations/_list.html.erb
+++ b/app/views/admin/illustrations/_list.html.erb
@@ -1,5 +1,5 @@
 <% if list.empty? %>
-<%=  empty_collection_message("No #{Illustration.model_name.human(count: :many).titleize.s} found.") %>
+<%=  empty_collection_message("No #{Illustration.model_name.human(count: :many).s} found.") %>
 <% else %>
    <table class="listGrid">
      <tr>

--- a/app/views/admin/summaries/_list.html.erb
+++ b/app/views/admin/summaries/_list.html.erb
@@ -1,5 +1,5 @@
 <% if list.empty? %>
-<%=  empty_collection_message("No #{Summary.model_name.human(count: :many).titleize.s} found.") %>
+<%=  empty_collection_message("No #{Summary.model_name.human(count: :many).s} found.") %>
 <% else %>
    <table class="listGrid">
      <tr>

--- a/app/views/admin/summaries/_list.html.erb
+++ b/app/views/admin/summaries/_list.html.erb
@@ -1,5 +1,5 @@
 <% if list.empty? %>
-<%=  empty_collection_message %>
+<%=  empty_collection_message("No #{Summary.model_name.human(count: :many).titleize.s} found.") %>
 <% else %>
    <table class="listGrid">
      <tr>


### PR DESCRIPTION
**MANU-7789** https://uvaissues.atlassian.net/browse/MANU-7789
 + fixes issue where each accordion section output "No Terms found" instead of "No (section name) found"

Please merge and deploy the corresponding TERMS_ENGINE pull request at the same time as this one:
https://github.com/shanti-uva/terms_engine/pull/75

Changes were requested in this doc: https://docs.google.com/document/d/1TwkQ02IK7vM_7wfq6ZoNZeyMbDZxOxzP16VvNIHuJHs/edit