### PR TITLE
MANU-7791

### DIFF
--- a/app/views/admin/illustrations/index.html.erb
+++ b/app/views/admin/illustrations/index.html.erb
@@ -7,7 +7,7 @@
 <div>
   <div class="right highlight">
 <% if parent? %>
-<%=  ts :for, :what => new_item_link([parent_object, :illustration]), :whom => feature_link(parent_object) %>
+  <%=  ts :for, :what => new_item_link([parent_object, :illustration], "New #{Illustration.model_name.human.s}"), :whom => feature_link(parent_object) %>
 <% end %>
   </div>
 </div>

--- a/app/views/admin/illustrations/index.html.erb
+++ b/app/views/admin/illustrations/index.html.erb
@@ -7,7 +7,7 @@
 <div>
   <div class="right highlight">
 <% if parent? %>
-  <%=  ts :for, :what => new_item_link([parent_object, :illustration], "New #{Illustration.model_name.human.s}"), :whom => feature_link(parent_object) %>
+<%=  ts :for, :what => new_item_link([parent_object, :illustration]), :whom => feature_link(parent_object) %>
 <% end %>
   </div>
 </div>

--- a/app/views/admin/summaries/_list.html.erb
+++ b/app/views/admin/summaries/_list.html.erb
@@ -5,6 +5,7 @@
      <tr>
        <th class="listActionsCol"></th>
        <th><%= Language.model_name.human.titleize.s %></th>
+       <th><%=  ts 'accordion.summary.excerpt' %></th>
        <th><%= Citation.model_name.human(:count => :many).titleize.s %></th>
      </tr>
 <%   list.each do |item| %>
@@ -15,6 +16,7 @@
          view_path: admin_feature_summary_path(item.feature, item)) %>
        </td>
        <td><%= item.language.name %></td>
+       <td><%= item.plain_content.truncate(250, separator: ' ') %></td>
        <td><%= accordion_citation_list_fieldset(object: item) %></td>
      </tr>
 <%   end %>

--- a/config/locales/bo/views.yml
+++ b/config/locales/bo/views.yml
@@ -90,3 +90,6 @@ bo:
     view:
         record: '%{what}ལ་ལྟ་ཞིབ་བྱས་པ།'
         this: 'ལྟ་ཞིབ།'
+    accordion:
+        summary:
+          excerpt: 'Excerpt'

--- a/config/locales/dz/views.yml
+++ b/config/locales/dz/views.yml
@@ -90,3 +90,6 @@ dz:
     view:
         record: 'View %{what}'
         this: 'View'
+    accordion:
+        summary:
+          excerpt: 'Excerpt'

--- a/config/locales/en/views.yml
+++ b/config/locales/en/views.yml
@@ -90,3 +90,6 @@ en:
     view:
         record: 'View %{what}'
         this: 'View'
+    accordion:
+        summary:
+          excerpt: 'Excerpt'

--- a/config/locales/zh/views.yml
+++ b/config/locales/zh/views.yml
@@ -90,3 +90,6 @@ zh:
     view:
         record: '查看%{what}'
         this: '查看'
+    accordion:
+        summary:
+          excerpt: 'Excerpt'


### PR DESCRIPTION
**MANU-7791 ** 

https://uvaissues.atlassian.net/browse/MANU-7791
 +  Add 'excerpt' to Summaries table. Adds translation item to config/locales/lang/views for "excerpt" and displays summary.plain_content truncated to 250 chars in the view.

https://uvaissues.atlassian.net/browse/MANU-7794
 + Change 'illustrations' to 'homepage images'. Adds translation to config/locales/[lang]/models in TERMS_ENGINE and uses that key in views. 
 + NOT DOING THIS ANY MORE - CHANGE REVERTED. Will update new_item_link helper instead.


Changes requested via https://docs.google.com/document/d/1TwkQ02IK7vM_7wfq6ZoNZeyMbDZxOxzP16VvNIHuJHs/edit#heading=h.uq3d5egrwqp5
