### PR TITLE
MANU-7851 move feature accordion js from terms_engine

### DIFF
--- a/app/assets/javascripts/kmaps_engine/features_admin_accordion.js
+++ b/app/assets/javascripts/kmaps_engine/features_admin_accordion.js
@@ -1,0 +1,65 @@
+  $(document).ready(function() {
+
+    if( $('.logged-in #featureShow #accordion').length ) { // only run this on the admin feature accordion
+
+      const section = window.location.href.split('=')[1];
+
+      switch(section) {
+     
+        case('captions'):
+          handleFeatureAccordion('collapseFour');
+          break;
+        case('collections'):
+          handleFeatureAccordion('collapseTwo');
+          break;
+        case('definitions'):
+          handleFeatureAccordion('collapseTen');
+          break;
+        case('descriptions'):
+          handleFeatureAccordion('#collapseNine');
+          break;
+        case('etymologies'):
+          handleFeatureAccordion('collapseThirteen');
+          break;
+        case('geocodes'):
+          handleFeatureAccordion('collapseSeven');
+          break;
+        case('illustrations'):
+          handleFeatureAccordion('collapseSix');
+          break;
+        case('names'):
+          handleFeatureAccordion('collapseThree');
+          break;
+        case('passages'):
+          handleFeatureAccordion('collapsePassages');
+          break;
+        case('recordings'):
+          handleFeatureAccordion('collapseEleven');
+          break;
+        case('relations'):
+          handleFeatureAccordion('collapseEight');
+          break;
+        case('subjectAssociations'):
+          handleFeatureAccordion('collapseTwelve');
+          break;
+        case('summaries'):
+          handleFeatureAccordion('collapseFive');
+          break;
+        default:
+          console.log("default");
+          break;
+      }
+    
+      function handleFeatureAccordion(el){
+        // General Information is shown by default so hide it
+        $('#collapseOne').collapse('hide');
+        $('#' + el).collapse('toggle');
+        setTimeout(1000);
+        //TODO there is something else running on the page that prevents this from working consistently.
+        //It has to do with the sidebar list of terms.
+        document.getElementById(el).scrollIntoView({behavior: "smooth" });
+      }
+    }
+});
+
+

--- a/config/initializers/assets.rb
+++ b/config/initializers/assets.rb
@@ -10,3 +10,4 @@ Rails.application.config.assets.precompile.concat(['kmaps_engine/admin.js', 'kma
   'gallery/default-skin.svg','kmaps_tree/jquery.fancytree-all.min.js','kmaps_tree/icons.gif'])
 Rails.application.config.assets.precompile.concat(['sarvaka_kmaps/*', 'collapsible_list/kmaps_collapsible_list.css', 'kmaps_tree/kmapstree.css', 'kmaps_engine/xml-books.css', 'kmaps_engine/gallery.css'])
 Rails.application.config.assets.precompile.concat(['collapsible_list/jquery.kmapsCollapsibleList.js'])
+Rails.application.config.assets.precompile.concat(['kmaps_engine/features_admin_accordion.js'])


### PR DESCRIPTION
https://uvaissues.atlassian.net/browse/MANU-7851

* javascript that shows the appropriate accordion section when returning to the accordion page after a form submission/cancellation. This file is included by the terms_engine admin/feature/show page and the code that depends on it is in PR https://github.com/shanti-uva/terms_engine/pull/77
