### PR TITLE
MANU-7887

### DIFF
--- a/app/helpers/admin_helper.rb
+++ b/app/helpers/admin_helper.rb
@@ -375,7 +375,7 @@ module AdminHelper
   #
   #
   def feature_names_link(feature=nil)
-    feature.nil? ? link_to('feature names', admin_feature_names_path) : link_to('names', admin_feature_feature_names_path(feature))
+    feature.nil? ? link_to('feature names', admin_feature_names_path) : link_to(FeatureName.model_name.human(count: :many).titleize.s, admin_feature_feature_names_path(feature))
   end
 
   #

--- a/app/views/admin/essays/edit.html.erb
+++ b/app/views/admin/essays/edit.html.erb
@@ -1,5 +1,5 @@
 <% add_breadcrumb_item feature_link(object.feature)
-   add_breadcrumb_item link_to 'essays', admin_feature_essays_path(object.feature)
+   add_breadcrumb_item link_to Essay.model_name.human(count: :many).titleize.s, admin_feature_essays_path(object.feature)
    add_breadcrumb_item object.id %>
 <section class="panel panel-content">
   <div class="panel-heading">

--- a/app/views/admin/essays/show.html.erb
+++ b/app/views/admin/essays/show.html.erb
@@ -1,5 +1,5 @@
 <% add_breadcrumb_item feature_link(object.feature)
-   add_breadcrumb_item link_to 'essays', admin_feature_essays_path(object.feature)
+   add_breadcrumb_item link_to Essay.model_name.human(count: :many).titleize.s, admin_feature_essays_path(object.feature)
 %>
 <section class="panel panel-content">
   <div class="panel-heading">


### PR DESCRIPTION
MANU-7887

Some views were using hardcoded strings for breadcrumb link output instead of using the model_name set in the translation files. This corrects that. This also requires changes made in kmaps_engine, pull request here:

Please see also https://github.com/shanti-uva/terms_engine/pull/78 for related changes
