### PR TITLE
MANU-7891 breadcrumb nav improvements (WIP)

### DIFF
--- a/app/assets/javascripts/kmaps_engine/descriptions_admin_accordion.js
+++ b/app/assets/javascripts/kmaps_engine/descriptions_admin_accordion.js
@@ -1,0 +1,38 @@
+$(document).ready(function() {
+
+    if( $('.logged-in.page-terms #descriptionShow #accordion').length ) { // only run this on the admin description accordion in terms_engine
+
+      const section = window.location.href.split('=')[1];
+      if( section == null || section === undefined ) { return; } // exit if we didn't get a section
+
+      switch(section) {
+     
+        case('general'):
+          handleFeatureAccordion('collapseOne');
+          break;
+        case('citations'):
+          handleFeatureAccordion('collapseTwo');
+          break;
+        case('notes'):
+          handleFeatureAccordion('collapseThree');
+          break;
+        case('dates'):
+          handleFeatureAccordion('collapseFour');
+          break;
+        default:
+          handleFeatureAccordion('collapseOne');
+          break;
+      }
+    
+      function handleFeatureAccordion(el){
+        // General Information is shown by default so hide it
+        $('#collapseOne').collapse('hide');
+        $('#' + el).collapse('toggle');
+        setTimeout(1000);
+        //TODO there is something else running on the page that prevents this from working consistently.
+        //It has to do with the sidebar list of terms.
+        document.getElementById(el).scrollIntoView({behavior: "smooth" });
+      }
+    }
+});
+

--- a/app/helpers/admin_helper.rb
+++ b/app/helpers/admin_helper.rb
@@ -258,7 +258,7 @@ module AdminHelper
       add_breadcrumb_item link_to(parent_object.content.strip_tags.truncate(25).s, admin_feature_definition_path(object.feature, parent_object, section: 'citations'))
     when :description
       add_breadcrumb_item feature_descriptions_link(parent_object.feature)
-      add_breadcrumb_item link_to(parent_object.id, admin_feature_description_path(parent_object.feature, parent_object))
+      add_breadcrumb_item link_to(parent_object.title.strip_tags.truncate(25).titleize.s, admin_feature_description_path(parent_object.feature, parent_object))
     when :feature
     when :feature_name
       add_breadcrumb_item feature_names_link(parent_object.feature)

--- a/app/helpers/admin_helper.rb
+++ b/app/helpers/admin_helper.rb
@@ -253,9 +253,9 @@ module AdminHelper
     # breadcrumbs for each of the parent types!
     add_breadcrumb_item feature_link(contextual_feature)
     case parent_type
-    when :definition
+    when :definition # in terms_engine
       add_breadcrumb_item link_to(Definition.model_name.human(:count => :many).s, admin_feature_path(object.feature.fid, section: 'definitions'))
-      add_breadcrumb_item link_to(parent_object.content.strip_tags.truncate(25).s, admin_definition_path(parent_object))
+      add_breadcrumb_item link_to(parent_object.content.strip_tags.truncate(25).s, admin_feature_definition_path(object.feature, parent_object, section: 'citations'))
     when :description
       add_breadcrumb_item feature_descriptions_link(parent_object.feature)
       add_breadcrumb_item link_to(parent_object.id, admin_feature_description_path(parent_object.feature, parent_object))
@@ -275,6 +275,8 @@ module AdminHelper
     when :feature_relation
       add_breadcrumb_item link_to(ts('relation.this', :count => :many), admin_feature_feature_relations_path(parent_object.child_node))
       add_breadcrumb_item feature_relation_role_label(parent_object.child_node, parent_object, :use_first=>false)
+    when :passage # in terms_engine
+      
     when :time_unit
       add_breadcrumb_item link_to(ts('date.this', :count => :many), admin_time_units_path)
       add_breadcrumb_item link_to(parent_object.to_s, polymorphic_path([:admin, parent_object]))
@@ -389,7 +391,7 @@ module AdminHelper
   end
 
   def feature_descriptions_link(feature=nil)
-    feature.nil? ? link_to('admin', admin_path) : link_to('essays', admin_feature_descriptions_path(feature))
+    feature.nil? ? link_to('admin', admin_path) : link_to(Description.model_name.human(count: :many).titleize.s, admin_feature_path(feature.fid, section: 'descriptions'))
   end
   #
   #

--- a/app/helpers/admin_helper.rb
+++ b/app/helpers/admin_helper.rb
@@ -261,10 +261,10 @@ module AdminHelper
       add_breadcrumb_item link_to(parent_object.title.strip_tags.truncate(25).titleize.s, admin_feature_description_path(parent_object.feature, parent_object))
     when :feature
     when :feature_name
-      add_breadcrumb_item feature_names_link(parent_object.feature)
-      add_breadcrumb_item link_to(parent_object.id, admin_feature_name_path(parent_object))
+      add_breadcrumb_item link_to(FeatureName.model_name.human(count: :many).titleize.s, admin_feature_path(parent_object.feature.fid, section: 'names'))
+      add_breadcrumb_item link_to(parent_object.name.strip_tags.truncate(25).s, admin_feature_name_path(parent_object))
     when :feature_name_relation
-      add_breadcrumb_item feature_names_link(parent_object.child_node.feature)
+      add_breadcrumb_item feature_names_link(parent_object.child_node.feature.fid)
       add_breadcrumb_item link_to(parent_object.child_node.name, admin_feature_name_path(parent_object.child_node))
       add_breadcrumb_item link_to(ts('relation.this', :count => :many), admin_feature_name_feature_name_relations_path(parent_object.child_node))
       add_breadcrumb_item link_to(parent_object, admin_feature_name_feature_name_relation_path(parent_object.child_node, parent_object))

--- a/app/helpers/admin_helper.rb
+++ b/app/helpers/admin_helper.rb
@@ -248,11 +248,14 @@ module AdminHelper
   end
 
   def add_breadcrumb_base
-    # Notes are polymorphic,
+    # Notes and Citations are polymorphic,
     # so we've gotta support
     # breadcrumbs for each of the parent types!
     add_breadcrumb_item feature_link(contextual_feature)
     case parent_type
+    when :definition
+      add_breadcrumb_item link_to(Definition.model_name.human(:count => :many).s, admin_feature_path(object.feature.fid, section: 'definitions'))
+      add_breadcrumb_item link_to(parent_object.content.strip_tags.truncate(25).s, admin_definition_path(parent_object))
     when :description
       add_breadcrumb_item feature_descriptions_link(parent_object.feature)
       add_breadcrumb_item link_to(parent_object.id, admin_feature_description_path(parent_object.feature, parent_object))

--- a/app/views/admin/affiliations/edit.html.erb
+++ b/app/views/admin/affiliations/edit.html.erb
@@ -1,6 +1,6 @@
 <% add_breadcrumb_item feature_link(object.feature)
-   add_breadcrumb_item link_to(Affiliation.model_name.human(count: :many).s, admin_feature_affiliations_path(object.feature))
-   add_breadcrumb_item link_to(object.id, object_path)
+   add_breadcrumb_item link_to(Affiliation.model_name.human(count: :many).s, admin_feature_path(object.feature.fid, section: 'collections'))
+   add_breadcrumb_item link_to(object.collection.name.blank? ? Collection.model_name.s : object.collection.name.strip_tags.truncate(25).s, object_path)
    add_breadcrumb_item ts('edit.this') %>
 <br class="clear"/>
 <section class="panel panel-content">

--- a/app/views/admin/affiliations/new.html.erb
+++ b/app/views/admin/affiliations/new.html.erb
@@ -1,5 +1,5 @@
 <%  add_breadcrumb_item feature_link(object.feature)
-    add_breadcrumb_item link_to(Affiliation.model_name.human(count: :many).s, collection_path)
+    add_breadcrumb_item link_to(Affiliation.model_name.human(count: :many).s, admin_feature_path(object.feature.fid, section: 'collections'))
     add_breadcrumb_item ts('new.this') %>
 <section class="panel panel-content">
   <div class="panel-heading">

--- a/app/views/admin/affiliations/show.html.erb
+++ b/app/views/admin/affiliations/show.html.erb
@@ -1,6 +1,6 @@
 <% add_breadcrumb_item feature_link(object.feature)
    add_breadcrumb_item link_to(Affiliation.model_name.human(:count => :many).s, admin_feature_affiliations_path(object.feature))
-   add_breadcrumb_item object.id %>
+   add_breadcrumb_item object.collection.name.blank? ? Collection.model_name.s : object.collection.name.strip_tags.truncate(25).s %>
 <p id="notice"><%= notice %></p>
 <br class="clear"/>
 <section class="panel panel-content">

--- a/app/views/admin/citations/_breadcrumbs.html.erb
+++ b/app/views/admin/citations/_breadcrumbs.html.erb
@@ -1,2 +1,11 @@
-<% add_breadcrumb_base
-   add_breadcrumb_item link_to(Citation.model_name.human(:count => :many).titleize.s, collection_path) %>
+<% 
+    add_breadcrumb_base
+
+case parent_type
+when :description
+  add_breadcrumb_item link_to(Citation.model_name.human(:count => :many).titleize.s, polymorphic_path([:admin, object.feature, object.citable], section: 'citations'))
+
+
+end
+#add_breadcrumb_item link_to(Citation.model_name.human(:count => :many).titleize.s, collection_path) 
+%>

--- a/app/views/admin/citations/_breadcrumbs.html.erb
+++ b/app/views/admin/citations/_breadcrumbs.html.erb
@@ -1,11 +1,4 @@
 <% 
-    add_breadcrumb_base
-
-case parent_type
-when :description
+  add_breadcrumb_base
   add_breadcrumb_item link_to(Citation.model_name.human(:count => :many).titleize.s, polymorphic_path([:admin, object.feature, object.citable], section: 'citations'))
-
-
-end
-#add_breadcrumb_item link_to(Citation.model_name.human(:count => :many).titleize.s, collection_path) 
 %>

--- a/app/views/admin/citations/show.html.erb
+++ b/app/views/admin/citations/show.html.erb
@@ -2,7 +2,7 @@
 <%  add_breadcrumb_item object.id %>
 <section class="panel panel-content">
   <div class="panel-heading">
-    <h6><%= ts :for, :what => Citation.model_name.human.titleize.s, :whom => object.citable_type.titleize %> <%= edit_item_link object %> <%= delete_item_link object %></h6>
+    <h6><%= ts :for, :what => Citation.model_name.human.titleize.s, :whom => object.citable.model_name.human.titleize %> <%= edit_item_link object %> <%= delete_item_link object %></h6>
   </div>
   <div class="panel-body">
 <fieldset>

--- a/app/views/admin/descriptions/edit.html.erb
+++ b/app/views/admin/descriptions/edit.html.erb
@@ -1,6 +1,6 @@
 <% add_breadcrumb_item feature_link(object.feature)
    add_breadcrumb_item feature_descriptions_link(object.feature)
-   add_breadcrumb_item link_to(object.id, admin_feature_description_path(parent_object,object))
+   add_breadcrumb_item link_to(object.title.strip_tags.truncate(25).s, admin_feature_description_path(parent_object,object))
    add_breadcrumb_item ts('edit.this') %>
 <div>
 <h1><%= ts 'edit.ing.record', what: "#{Description.model_name.human.titleize} #{object.id}" %></h1>
@@ -13,7 +13,7 @@
   <div class="panel-body">
 <%= form_for object, url: admin_feature_description_path(parent_object,object), method: :put do |f| %>
 <%=  render partial: 'form_fields', locals: { f: f} %>
-<%= link_to(ts('cancel.this'), parent_object.nil? ? collection_path : admin_feature_path(parent_object.fid), class: 'btn btn-primary form-submit', id: 'edit-cancel') %> | <%= globalized_submit_tag 'update.this', class: 'btn btn-primary form-submit' %>
+<%= link_to(ts('cancel.this'), parent_object.nil? ? collection_path : admin_feature_path(parent_object.fid, section: 'descriptions'), class: 'btn btn-primary form-submit', id: 'edit-cancel') %> | <%= globalized_submit_tag 'update.this', class: 'btn btn-primary form-submit' %>
 <% end %>
   </div> <!-- END panel-body -->
 </section> <!-- END panel -->

--- a/app/views/admin/descriptions/new.html.erb
+++ b/app/views/admin/descriptions/new.html.erb
@@ -16,7 +16,7 @@
 <%=  f.hidden_field :feature_id, value: params[:feature_id] %>
 <%=  render partial: 'form_fields', locals: {f: f, object: object} %>
 <%   #Make the cancel link go back to the selected feature's descriptions if it exists %>
-<%=  link_to(ts('cancel.this'), parent_object.nil? ? collection_path : admin_feature_path(parent_object.fid), class: 'btn btn-primary form-submit', id: 'edit-cancel') %> |
+<%=  link_to(ts('cancel.this'), parent_object.nil? ? collection_path : admin_feature_path(parent_object.fid, section: 'descriptions'), class: 'btn btn-primary form-submit', id: 'edit-cancel') %> |
 <%=  globalized_submit_tag 'creat.e.this', class: 'submit btn btn-primary form-submit' %>
 <% end %>
   </div> <!-- END panel-body -->

--- a/app/views/admin/descriptions/show.html.erb
+++ b/app/views/admin/descriptions/show.html.erb
@@ -2,7 +2,7 @@
    add_breadcrumb_item feature_descriptions_link(object.feature)
    add_breadcrumb_item object.title.strip_tags.truncate(25).s %>
 <div>
-  <h1><%= Description.model_name.human.titleize.s %>: <%= object.id %></h1>
+  <h1><%= Description.model_name.human.titleize.s %>: <%= object.title %></h1>
 </div>
 <br class="clear"/>
 <section class="panel panel-content">
@@ -10,6 +10,7 @@
     <h6><%= Description.model_name.human.titleize.s %></h6>
   </div>
   <div class="panel-body">
+    <div id="descriptionShow" style="position:relative;">
   <div id="accordion" class="panel-group">
 <section class="panel panel-default">
     <div class="panel-heading">
@@ -84,5 +85,7 @@
   </div> <!-- END collapseFour -->
 </section> <!-- END panel -->
   </div> <!-- END accordion -->
+  </div><!-- END descriptionShow -->
   </div> <!-- END panel-body -->
 </section> <!-- END panel -->
+<%= javascript_include_tag "kmaps_engine/descriptions_admin_accordion.js" %>

--- a/app/views/admin/descriptions/show.html.erb
+++ b/app/views/admin/descriptions/show.html.erb
@@ -1,6 +1,6 @@
 <% add_breadcrumb_item feature_link(object.feature)
    add_breadcrumb_item feature_descriptions_link(object.feature)
-   add_breadcrumb_item object.id %>
+   add_breadcrumb_item object.title.strip_tags.truncate(25).s %>
 <div>
   <h1><%= Description.model_name.human.titleize.s %>: <%= object.id %></h1>
 </div>

--- a/app/views/admin/feature_names/index.html.erb
+++ b/app/views/admin/feature_names/index.html.erb
@@ -6,8 +6,8 @@ end
 if @locating_relation
   add_breadcrumb_item features_link
   add_breadcrumb_item feature_link(object.feature)
-  add_breadcrumb_item link_to(FeatureName.model_name.human(:count => :many).s, admin_feature_feature_names_path(object.feature))
-  add_breadcrumb_item link_to(object.id, admin_feature_feature_name_path(object.feature, object))
+  add_breadcrumb_item link_to(FeatureName.model_name.human(:count => :many).titleize.s, admin_feature_path(object.feature.fid, section: 'names'))
+  add_breadcrumb_item link_to(object.name.strip_tags.truncate(25).titleize.s, admin_feature_feature_name_path(object.feature, object))
   add_breadcrumb_item ts('relat.ion.location')
 end %>
 <div>

--- a/app/views/admin/feature_names/prioritize.html.erb
+++ b/app/views/admin/feature_names/prioritize.html.erb
@@ -52,7 +52,7 @@
      </table>
 <% end %>
     <div class="returnLink">
-<%= link_to "&#8592; #{ts 'snippet.feature.return'}".html_safe, admin_feature_path(@feature.fid) %>
+<%= link_to "&#8592; #{ts 'snippet.feature.return'}".html_safe, admin_feature_path(@feature.fid, section: 'names') %>
     </div>
   </div> <!-- END panel-body -->
 </section> <!-- END panel -->

--- a/app/views/admin/notes/_breadcrumbs.html.erb
+++ b/app/views/admin/notes/_breadcrumbs.html.erb
@@ -1,2 +1,2 @@
 <% add_breadcrumb_base
-   add_breadcrumb_item link_to('notes', collection_path) %>
+   add_breadcrumb_item link_to(Note.model_name.human(count: :many).titleize.s, polymorphic_path([:admin, object.feature, object.notable], section: 'notes')) %>

--- a/app/views/admin/notes/edit.html.erb
+++ b/app/views/admin/notes/edit.html.erb
@@ -1,5 +1,5 @@
 <%= render partial: 'breadcrumbs' %>
-<%  add_breadcrumb_item link_to(object.id, object_path(object))
+<%  add_breadcrumb_item link_to(object.title.blank? ? object.id : object.title.strip_tags.truncate(25).s, object_path(object))
     add_breadcrumb_item ts('edit.this') %>
 <section class="panel panel-content">
   <div class="panel-heading">
@@ -8,7 +8,7 @@
   <div class="panel-body">
 <%= form_for object, url: polymorphic_path([:admin, parent_object, object]), method: :put do |f| %>
 <%=   render partial: 'form_fields', locals: {f: f, object: object} %>
-<%=   link_to ts('cancel.this'), polymorphic_path(stacked_parents), class: 'btn btn-primary form-submit', id: 'edit-cancel' %>
+<%=   link_to ts('cancel.this'), polymorphic_path(stacked_parents, section: 'notes'), class: 'btn btn-primary form-submit', id: 'edit-cancel' %>
 | <%= globalized_submit_tag 'update.this', class: 'btn btn-primary form-submit' %>
 <%  end %>
   </div> <!-- END panel-body -->

--- a/app/views/admin/notes/new.html.erb
+++ b/app/views/admin/notes/new.html.erb
@@ -9,7 +9,7 @@
 <%=   f.hidden_field :notable_id %>
 <%=   f.hidden_field :notable_type %>
 <%=   render partial: 'form_fields', locals: {f: f,object: object} %>
-<%=   link_to ts('cancel.this'), polymorphic_path(stacked_parents), class: 'btn btn-primary form-submit', id: 'edit-cancel' %> | <%= globalized_submit_tag 'creat.e.this', class: 'btn btn-primary form-submit' %>
+<%=   link_to ts('cancel.this'), polymorphic_path(stacked_parents, section: 'notes'), class: 'btn btn-primary form-submit', id: 'edit-cancel' %> | <%= globalized_submit_tag 'creat.e.this', class: 'btn btn-primary form-submit' %>
 <%  end %>
   </div> <!-- END panel-body -->
 </section> <!-- END panel -->

--- a/app/views/admin/notes/show.html.erb
+++ b/app/views/admin/notes/show.html.erb
@@ -1,5 +1,5 @@
 <%= render :partial => 'breadcrumbs' %>
-<%  add_breadcrumb_item object.id %>
+<%  add_breadcrumb_item object.title.blank? ? object.id : object.title.strip_tags.truncate(25).s %>
 <section class="panel panel-content">
   <div class="panel-heading">
     <h6><%= Note.model_name.human.titleize.s %></h6>

--- a/config/initializers/assets.rb
+++ b/config/initializers/assets.rb
@@ -10,3 +10,4 @@ Rails.application.config.assets.precompile.concat(['kmaps_engine/admin.js', 'kma
   'gallery/default-skin.svg','kmaps_tree/jquery.fancytree-all.min.js','kmaps_tree/icons.gif'])
 Rails.application.config.assets.precompile.concat(['sarvaka_kmaps/*', 'collapsible_list/kmaps_collapsible_list.css', 'kmaps_tree/kmapstree.css', 'kmaps_engine/xml-books.css', 'kmaps_engine/gallery.css'])
 Rails.application.config.assets.precompile.concat(['collapsible_list/jquery.kmapsCollapsibleList.js'])
+Rails.application.config.assets.precompile.concat(['kmaps_engine/descriptions_admin_accordion.js'])


### PR DESCRIPTION
https://uvaissues.atlassian.net/browse/MANU-7821
* Improve breadcrumb nav. Sometimes it links to irrelevant and/or "dead end" pages that are confusing for users.

There are a few commits from other tickets: 7873 (but this ticket should not be moved into TESTING yet - needs more work)
and MANU-7777 which is already in TESTING and doesn't need to be moved.