### PR TITLE
MANU-7929 Removes HOME link from breadcrumbs

### DIFF
--- a/app/helpers/admin_helper.rb
+++ b/app/helpers/admin_helper.rb
@@ -234,7 +234,7 @@ module AdminHelper
     #@breadcrumbs.unshift link_to_unless_current('features', admin_features_path)
     #@breadcrumbs.to_a.join(' > ').html_safe
     @breadcrumbs ||= []
-    list = [link_to("#{ts('home.this')}:".html_safe, admin_root_path)]+@breadcrumbs[0...@breadcrumbs.size-1].collect{|e| "#{e}#{breadcrumb_separator}".html_safe} + [@breadcrumbs.last]
+    list = @breadcrumbs[0...@breadcrumbs.size-1].collect{|e| "#{e}#{breadcrumb_separator}".html_safe} + [@breadcrumbs.last]
     content_tag :ol, list.collect{|e| "<li>#{e}</li>"}.join.html_safe, class: 'breadcrumb'
   end
 


### PR DESCRIPTION
https://uvaissues.atlassian.net/browse/MANU-7792

* removes HOME link from breadcrumbs as it loads the admin layout with no content, which does not provide any utility.