### PR TITLE
MANU-7939 adding NOTES admin to passage translations, passages, etymologies and definitions in Terms

### DIFF
--- a/app/views/admin/notes/_breadcrumbs.html.erb
+++ b/app/views/admin/notes/_breadcrumbs.html.erb
@@ -1,2 +1,15 @@
-<% add_breadcrumb_base
-   add_breadcrumb_item link_to(Note.model_name.human(count: :many).titleize.s, polymorphic_path([:admin, object.feature, object.notable], section: 'notes')) %>
+<% 
+  add_breadcrumb_base
+
+  # if object.notable is nested more deeply than a Feature,
+# we need to link to object.notable.context instead of object.feature
+# need to regression test this change, not sure how it'll impact TODO
+#
+# Should the link below go to object.notable.context instead of object.notable?
+# for example if the note's lineage is FEature > Definition > Passage > Note
+# would we link to Definition with the passage section expanded? hrm
+
+  # add_breadcrumb_item link_to(Note.model_name.human(count: :many).titleize.s, polymorphic_path([:admin, object.feature, object.notable], section: 'notes'))
+  add_breadcrumb_item link_to(Note.model_name.human(count: :many).titleize.s, polymorphic_path([:admin, object.notable.context, object.notable], section: 'notes')) 
+%>
+

--- a/app/views/admin/notes/_breadcrumbs.html.erb
+++ b/app/views/admin/notes/_breadcrumbs.html.erb
@@ -1,4 +1,5 @@
 <% 
+    
   add_breadcrumb_base
 
   # if object.notable is nested more deeply than a Feature,
@@ -9,7 +10,11 @@
 # for example if the note's lineage is FEature > Definition > Passage > Note
 # would we link to Definition with the passage section expanded? hrm
 
-  # add_breadcrumb_item link_to(Note.model_name.human(count: :many).titleize.s, polymorphic_path([:admin, object.feature, object.notable], section: 'notes'))
-  add_breadcrumb_item link_to(Note.model_name.human(count: :many).titleize.s, polymorphic_path([:admin, object.notable.context, object.notable], section: 'notes')) 
+
+if object.notable.respond_to? :context
+  add_breadcrumb_item link_to(Note.model_name.human(count: :many).titleize.s, polymorphic_path([:admin, object.notable.context, object.notable], section: 'notes'))
+else
+  add_breadcrumb_item link_to(Note.model_name.human(count: :many).titleize.s, polymorphic_path([:admin, object.feature, object.notable], section: 'notes'))
+end
 %>
 

--- a/app/views/admin/notes/_breadcrumbs.html.erb
+++ b/app/views/admin/notes/_breadcrumbs.html.erb
@@ -1,15 +1,8 @@
 <% 
-    
-  add_breadcrumb_base
+add_breadcrumb_base
 
-  # if object.notable is nested more deeply than a Feature,
+# if object.notable is nested more deeply than a Feature,
 # we need to link to object.notable.context instead of object.feature
-# need to regression test this change, not sure how it'll impact TODO
-#
-# Should the link below go to object.notable.context instead of object.notable?
-# for example if the note's lineage is FEature > Definition > Passage > Note
-# would we link to Definition with the passage section expanded? hrm
-
 
 if object.notable.respond_to? :context
   add_breadcrumb_item link_to(Note.model_name.human(count: :many).titleize.s, polymorphic_path([:admin, object.notable.context, object.notable], section: 'notes'))


### PR DESCRIPTION
https://uvaissues.atlassian.net/browse/MANU-7939

This change was made in service of the above ticket but really just changes how we handle breadcrumbs for deeper nested notes. If the note.notable responds to context, link the breadcrumb to that. Otherwise use the note's feature.