### PR TITLE
MANU-7969 change Page model page num fields from int to string

### DIFF
--- a/db/migrate/20260505124154_change_page_no_to_string.rb
+++ b/db/migrate/20260505124154_change_page_no_to_string.rb
@@ -1,0 +1,6 @@
+class ChangePageNoToString < ActiveRecord::Migration[8.1]
+  def change
+    change_column :pages, :start_page, :string 
+    change_column :pages, :end_page, :string
+  end
+end


### PR DESCRIPTION
**MANU-7969** 

Request from Steve to be able to enter page numbers such as "2a" which is currently not possible with the integer datatype of the page.start_page and page.end_page fields

Created a migration to change the datatype of the field